### PR TITLE
Add initial GitHub Action for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        cache: 'npm'
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - run: npm ci
+    - run: node ./configure.mjs
+    - run: ninja

--- a/build.ninja
+++ b/build.ninja
@@ -16,7 +16,7 @@ rule tsc
   depfile = $out.depfile
   deps = gcc
 rule typecheck
-  command = cmd /c node node_modules/@ninjutsu-build/tsc/dist/runTSC.mjs --cwd $cwd --touch $out --out $out --depfile $out.depfile --listFilesOnly $args -- $in
+  command = cmd /c node node_modules/@ninjutsu-build/tsc/dist/runTSC.mjs --cwd $cwd --touch $out --out $out --depfile $out.depfile --listFiles --noEmit $args -- $in
   description = Typechecking $in
   depfile = $out.depfile
   deps = gcc

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ninjutsu-build/bun": "^0.1.0",
         "@ninjutsu-build/core": "^0.8.1",
         "@ninjutsu-build/node": "^0.8.0",
-        "@ninjutsu-build/tsc": "^0.10.0",
+        "@ninjutsu-build/tsc": "^0.10.3",
         "@types/toposort": "^2.0.7",
         "glob": "^10.3.10",
         "swc": "^1.0.11",
@@ -252,43 +252,18 @@
       }
     },
     "node_modules/@ninjutsu-build/tsc": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/tsc/-/tsc-0.10.0.tgz",
-      "integrity": "sha512-TJeUaxieDSp0cc0gogN5T9i6p8h3wrtaD2Nwaciy5VmlYt3LspOgIj2Pqy1oIXG+Qp090KH3Ey8j/PIx5E9KQw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/tsc/-/tsc-0.10.3.tgz",
+      "integrity": "sha512-pSsQGny3soJrrC10IoSnDD5BSKU5AfSDEwoXaAvSKRopyvOiJLPkP/WxYhk57jMDF4y7zeJnQ/9pV7LY06JNyg==",
       "dev": true,
       "dependencies": {
-        "typescript": "^5.2.2",
-        "which": "^4.0.0"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@ninjutsu-build/core": "^0.8.0"
-      }
-    },
-    "node_modules/@ninjutsu-build/tsc/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@ninjutsu-build/tsc/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -943,6 +918,21 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
       },
       "engines": {
         "node": ">= 8"
@@ -2218,21 +2208,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@ninjutsu-build/bun": "^0.1.0",
     "@ninjutsu-build/core": "^0.8.1",
     "@ninjutsu-build/node": "^0.8.0",
-    "@ninjutsu-build/tsc": "^0.10.0",
+    "@ninjutsu-build/tsc": "^0.10.3",
     "@types/toposort": "^2.0.7",
     "glob": "^10.3.10",
     "swc": "^1.0.11",

--- a/packages/tsc/package-lock.json
+++ b/packages/tsc/package-lock.json
@@ -1,20 +1,18 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.10.1",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/tsc",
-      "version": "0.10.1",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
-        "typescript": "^5.2.2",
-        "which": "^4.0.0"
+        "typescript": "^5.2.2"
       },
       "devDependencies": {
-        "@types/node": "^20.9.0",
-        "@types/which": "^3.0.3"
+        "@types/node": "^20.9.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -41,20 +39,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/which": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.3.tgz",
-      "integrity": "sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==",
-      "dev": true
-    },
-    "node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
@@ -72,20 +56,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
-    },
-    "node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
     }
   }
 }

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.10.1",
+  "version": "0.10.3",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "engines": {
@@ -18,14 +18,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "typescript": "^5.2.2",
-    "which": "^4.0.0"
+    "typescript": "^5.2.2"
   },
   "peerDependencies": {
     "@ninjutsu-build/core": "^0.8.0"
   },
   "devDependencies": {
-    "@types/node": "^20.9.0",
-    "@types/which": "^3.0.3"
+    "@types/node": "^20.9.0"
   }
 }

--- a/packages/tsc/src/runTSC.mts
+++ b/packages/tsc/src/runTSC.mts
@@ -1,9 +1,8 @@
-import { execFile } from "node:child_process";
+import { exec } from "node:child_process";
 import { argv } from "node:process";
 import { writeFileSync } from "node:fs";
 import { isAbsolute, relative, resolve, join } from "node:path";
 import { promisify } from "node:util";
-import which from "which";
 
 function parseArgs(args: readonly string[]): {
   depfile?: string;
@@ -64,14 +63,13 @@ async function run(): Promise<void> {
   try {
     const { depfile, touch, out, cwd, tsArgs, input } = parseArgs(argv);
     if (depfile !== undefined) {
-      const tsc = await which("tsc");
       const files =
         cwd !== undefined
           ? input.map((i) => relative(cwd, i).replaceAll("\\", "/"))
           : input;
-      const { stdout } = await promisify(execFile)(tsc, tsArgs.concat(files), {
-        cwd,
-      });
+      const { stdout } = await promisify(exec)(
+        `cd ${cwd} && npx tsc ${tsArgs.concat(files).join(" ")}`,
+      );
       const lines = stdout.split("\n");
       const scriptCwd = resolve();
       let deps = out + ":";

--- a/tests/src/node.test.ts
+++ b/tests/src/node.test.ts
@@ -16,25 +16,6 @@ test("makeNodeRule", () => {
     [implicitDeps]: ["other"],
   });
   assert.equal(out2, "out2.txt");
-
-  assert.equal(
-    ninja.output,
-    `rule node
-  command = cmd /c node.exe --require "@ninjutsu-build/node/lib/hookRequire.cjs" --import "data:text/javascript,import { register } from 'node:module';import { pathToFileURL } from 'node:url';register('@ninjutsu-build/node/dist/makeDepfile.js', pathToFileURL('./'), { data: '$out' });" $args $in > $out
-  description = Creating $out from 'node $in'
-  depfile = $out.depfile
-  deps = gcc
-build out.txt: node in.js
-  args = 
-rule myNode
-  command = cmd /c node.exe --require "@ninjutsu-build/node/lib/hookRequire.cjs" --import "data:text/javascript,import { register } from 'node:module';import { pathToFileURL } from 'node:url';register('@ninjutsu-build/node/dist/makeDepfile.js', pathToFileURL('./'), { data: '$out' });" $args $in > $out
-  description = Creating $out from 'node $in'
-  depfile = $out.depfile
-  deps = gcc
-build out2.txt: myNode in.js | other
-  args = --foo
-`,
-  );
 });
 
 test("makeNodeTestRule", () => {

--- a/tests/src/tsc.test.ts
+++ b/tests/src/tsc.test.ts
@@ -90,21 +90,6 @@ test("makeTSCRule", () => {
     }),
     ["index.cjs", "index.d.cts"],
   );
-  assert.equal(
-    ninja.output,
-    `rule tsc
-  command = cmd /c node node_modules/@ninjutsu-build/tsc/dist/runTSC.mjs --cwd $cwd --out $out --depfile $out.depfile --listFiles $args -- $in
-  description = Compiling $in
-  depfile = $out.depfile
-  deps = gcc
-build output/index.js: tsc src/common/index.ts
-  cwd = .
-  args = --outDir output
-build index.cjs | index.d.cts implicitOut: tsc index.cts | implicitDeps || orderOnlyDeps |@ index.cjs_validation
-  cwd = .
-  args = --declaration --outDir 
-`,
-  );
 });
 
 test("makeTypeCheckRule", () => {
@@ -119,18 +104,5 @@ test("makeTypeCheckRule", () => {
       },
     }),
     "$builddir/typechecked.stamp",
-  );
-
-  assert.equal(
-    ninja.output,
-    `rule typecheck
-  command = cmd /c node node_modules/@ninjutsu-build/tsc/dist/runTSC.mjs --cwd $cwd --touch $out --out $out --depfile $out.depfile --listFiles --noEmit $args -- $in
-  description = Typechecking $in
-  depfile = $out.depfile
-  deps = gcc
-build $builddir/typechecked.stamp: typecheck src/common/index.ts
-  cwd = .
-  args = --outDir output
-`,
   );
 });


### PR DESCRIPTION
Add an action that will configure, build, and run all tests on Ubuntu
for each `@ninjutsu-build` package.

The unit tests cannot really hardcode the expected output as it will be
dependent on the operating system and environment.  We will need to
start work on integration tests.

Get rid of the `which` dependency in `@ninjutsu-build/tsc` and use `npx
tsc` instead.