### PR TITLE
Fix `tsc` when using `cwd`

### DIFF
--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "engines": {

--- a/packages/tsc/src/tsc.ts
+++ b/packages/tsc/src/tsc.ts
@@ -16,7 +16,8 @@ import type {
 } from "typescript";
 import ts from "typescript";
 import { platform } from "os";
-import { join } from "path";
+import { join } from "node:path";
+import { relative } from "node:path/posix";
 
 function compilerOptionToArray(
   name: string,
@@ -249,8 +250,9 @@ export function makeTSCRule(
       [implicitOut]: _implicitOut = [],
       ...rest
     } = a;
+    const input = getInputs(a.in).map((f) => relative(cwd, f));
     const argsArr = compilerOptionsToArray(compilerOptions);
-    const commandLine = ts.parseCommandLine(getInputs(a.in).concat(argsArr));
+    const commandLine = ts.parseCommandLine(input.concat(argsArr));
 
     // We need to set this to something, else we get a debug exception
     // in `getOutputFileNames`

--- a/tests/src/tsc.test.ts
+++ b/tests/src/tsc.test.ts
@@ -90,6 +90,29 @@ test("makeTSCRule", () => {
     }),
     ["index.cjs", "index.d.cts"],
   );
+
+  assert.deepEqual(
+    tsc({
+      in: ["package/src/index.cts"],
+      compilerOptions: {
+        outDir: "dist",
+      },
+      cwd: "package",
+    }),
+    ["package/dist/index.cjs"],
+  );
+
+  assert.deepEqual(
+    tsc({
+      in: ["package/src/index.cts"],
+      compilerOptions: {
+        outDir: "dist",
+        rootDir: ".",
+      },
+      cwd: "package",
+    }),
+    ["package/dist/src/index.cjs"],
+  );
 });
 
 test("makeTypeCheckRule", () => {


### PR DESCRIPTION
We did not previously strip the `cwd` prefix from the inputs to the `@ninjutsu-build/tsc` rules.  This meant that when using `rootDir` we would end up with incorrect paths returned when using a `cwd` parameter.