### PR TITLE
All `phony` to take an array of targets

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/core",
-  "version": "0.8.3",
+  "version": "0.8.5",
   "description": "Easily create ninja build files with this TypeScript library (https://ninja-build.org/)",
   "author": "Elliot Goodrich",
   "engines": {

--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -146,10 +146,18 @@ test("phony rule", () => {
   const out2: "my:: alia$ !" = phony({ out: "my:: alia$ !", in: "file$ .txt" });
   assert.equal(out2, "my:: alia$ !");
 
+  const out3: "all" = phony({ out: "all", in: ["in1", "in2"] });
+  assert.equal(out3, "all");
+
+  const out4: "none" = phony({ out: "none", in: [] });
+  assert.equal(out4, "none");
+
   assert.equal(
     ninja.output,
     `build alias: phony file.txt
 build my$:$:$ alia$$ !: phony file$$ .txt
+build all: phony in1 in2
+build none: phony
 `,
   );
 });

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -398,13 +398,19 @@ export class NinjaBuilder {
    * ninja.default(foo, mybar);
    * ```
    */
-  get phony(): <O extends string>(args: { out: O; in: string }) => O {
-    return <O extends string>(args: { out: O; in: string }): O => {
+  get phony(): <O extends string>(args: {
+    out: O;
+    in: string | readonly string[];
+  }) => O {
+    return <O extends string>(args: {
+      out: O;
+      in: string | readonly string[];
+    }): O => {
       this.output +=
         "build " +
         escapePath(args.out) +
-        ": phony " +
-        escapePath(args.in) +
+        ": phony" +
+        concatPaths(" ", args.in) +
         "\n";
       return args.out;
     };


### PR DESCRIPTION
The `phony` rule can actually take multiple targets and not just one. My initial reading of the documentation missed this.

Double bump the version as 0.8.4 had a trailing space for `phony` rules
with no inputs.  This isn't an issue for `ninja`, but does not match our
other rules.