### PR TITLE
Add phony targets for each package

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -82,6 +82,7 @@ build $builddir/core/dist/core.d.ts: copy packages/core/dist/core.d.ts
 build $builddir/ninjutsu-build-core.tgz: tar $builddir/core/README.md $builddir/core/package.json $builddir/core/dist/core.js $builddir/core/dist/core.d.ts
   files = core/README.md core/package.json core/dist/core.js core/dist/core.d.ts
   args = -C $builddir
+build core: phony $builddir/ninjutsu-build-core.tgz $builddir/core/packages/core/dist/core.test.mjs.result.txt
 
 # packages/biome
 build $builddir/.ninjutsu-build/biome/format/packages/biome/package.json: format packages/biome/package.json | ./biome.json || node_modules/.package-lock.json
@@ -123,6 +124,7 @@ build $builddir/biome/dist/biome.d.ts: copy packages/biome/dist/biome.d.ts
 build $builddir/ninjutsu-build-biome.tgz: tar $builddir/biome/README.md $builddir/biome/package.json $builddir/biome/dist/biome.js $builddir/biome/dist/biome.d.ts
   files = biome/README.md biome/package.json biome/dist/biome.js biome/dist/biome.d.ts
   args = -C $builddir
+build biome: phony $builddir/ninjutsu-build-biome.tgz $builddir/biome/packages/biome/dist/biome.test.mjs.result.txt
 
 # packages/bun
 build $builddir/.ninjutsu-build/biome/format/packages/bun/package.json: format packages/bun/package.json | ./biome.json || node_modules/.package-lock.json
@@ -150,6 +152,7 @@ build $builddir/bun/dist/bun.d.ts: copy packages/bun/dist/bun.d.ts
 build $builddir/ninjutsu-build-bun.tgz: tar $builddir/bun/README.md $builddir/bun/package.json $builddir/bun/dist/bun.js $builddir/bun/dist/bun.d.ts
   files = bun/README.md bun/package.json bun/dist/bun.js bun/dist/bun.d.ts
   args = -C $builddir
+build bun: phony $builddir/ninjutsu-build-bun.tgz
 
 # packages/node
 build $builddir/.ninjutsu-build/biome/format/packages/node/package.json: format packages/node/package.json | ./biome.json || node_modules/.package-lock.json
@@ -232,6 +235,7 @@ build $builddir/node/lib/file.cjs: copy packages/node/lib/file.cjs || $builddir/
 build $builddir/ninjutsu-build-node.tgz: tar $builddir/node/README.md $builddir/node/package.json $builddir/node/dist/node.js $builddir/node/dist/node.d.ts $builddir/node/dist/makeDepfile.js $builddir/node/dist/makeDepfile.d.ts $builddir/node/lib/testReporter.mjs $builddir/node/lib/hookRequire.cjs $builddir/node/lib/file.d.cts $builddir/node/lib/file.cjs
   files = node/README.md node/package.json node/dist/node.js node/dist/node.d.ts node/dist/makeDepfile.js node/dist/makeDepfile.d.ts node/lib/testReporter.mjs node/lib/hookRequire.cjs node/lib/file.d.cts node/lib/file.cjs
   args = -C $builddir
+build node: phony $builddir/ninjutsu-build-node.tgz $builddir/node/packages/node/dist/node.test.mjs.result.txt
 
 # packages/tsc
 build $builddir/.ninjutsu-build/biome/format/packages/tsc/package.json: format packages/tsc/package.json | ./biome.json || node_modules/.package-lock.json
@@ -273,3 +277,4 @@ build $builddir/tsc/dist/tsc.d.ts: copy packages/tsc/dist/tsc.d.ts
 build $builddir/ninjutsu-build-tsc.tgz: tar $builddir/tsc/README.md $builddir/tsc/package.json $builddir/tsc/dist/tsc.js $builddir/tsc/dist/tsc.d.ts
   files = tsc/README.md tsc/package.json tsc/dist/tsc.js tsc/dist/tsc.d.ts
   args = -C $builddir
+build tsc: phony $builddir/ninjutsu-build-tsc.tgz $builddir/tsc/packages/tsc/dist/tsc.test.mjs.result.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@biomejs/biome": "1.4.0",
         "@ninjutsu-build/biome": "^0.7.0",
         "@ninjutsu-build/bun": "^0.1.0",
-        "@ninjutsu-build/core": "^0.8.1",
+        "@ninjutsu-build/core": "^0.8.5",
         "@ninjutsu-build/node": "^0.8.0",
         "@ninjutsu-build/tsc": "^0.10.5",
         "@types/toposort": "^2.0.7",
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.2.tgz",
-      "integrity": "sha512-mQhutAJt2znWKl2N4TrFcmv2h3cpnkOnXT/PTXA9LXjgsruIgRnQP5rSp3brZTavanPjtPmXOga45uv3e7UTSQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.5.tgz",
+      "integrity": "sha512-iswKbkfoxEeHSJqktsf42Xc2uaJotDrI7+z49ThEwUNsJH/c+7b0q0A2XO0O0UxbBMQy+k8cbmrahDQ1Ioq6iQ==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@biomejs/biome": "1.4.0",
     "@ninjutsu-build/biome": "^0.7.0",
     "@ninjutsu-build/bun": "^0.1.0",
-    "@ninjutsu-build/core": "^0.8.1",
+    "@ninjutsu-build/core": "^0.8.5",
     "@ninjutsu-build/node": "^0.8.0",
     "@ninjutsu-build/tsc": "^0.10.5",
     "@types/toposort": "^2.0.7",

--- a/packages/biome/package.json
+++ b/packages/biome/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A biome plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
+  "scripts": {
+    "test": "ninja biome -C ../.."
+  },
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@ninjutsu-build/bun",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A bun plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
+  "scripts": {
+    "test": "ninja bun -C ../.."
+  },
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@ninjutsu-build/core",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Easily create ninja build files with this TypeScript library (https://ninja-build.org/)",
   "author": "Elliot Goodrich",
+  "scripts": {
+    "test": "ninja core -C ../.."
+  },
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
+  "scripts": {
+    "test": "ninja node -C ../.."
+  },
   "engines": {
     "node": ">=18.18.0"
   },

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
+  "scripts": {
+    "test": "ninja tsc -C ../.."
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
If working on `node`, we do not need to run or test any code for the other plugins.  Right now it is hard to do this without remembering exactly what the outputs are for `node`.

This commit adds a phony rule `node` that will run all unit tests and build the `.tgz` archive for the `node` plugin (and similarly for other packages we can use `ninja [packageName]`).

Additionally we add `test` scripts to each package because one of the metrics that packages are rated on is the fact they have unit tests and an associated `npm test` script.