### PR TITLE
Fix `@ninjutsu-build/node` args variable

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/node/src/node.test.ts
+++ b/packages/node/src/node.test.ts
@@ -12,6 +12,7 @@ test("makeNodeRule", () => {
   const out2: "out2.txt" = myNode({
     out: "out2.txt",
     in: "in.js",
+    nodeArgs: "--allow-worker",
     args: "--foo",
     [implicitDeps]: ["other"],
   });

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -22,8 +22,8 @@ const importCode =
 // we mention `node.exe` with the file extension to avoid the `winpty node` alias.
 const node = platform() === "win32" ? "cmd /c node.exe" : "node";
 
-const command = `${node} --require "${hookRequire}" --import "data:text/javascript,${importCode}" $args $in > $out`;
-const testCommand = `${node} --require "${hookRequire}" --import "data:text/javascript,${importCode}" --test --test-reporter=${testReporter} --test-reporter=tap --test-reporter-destination=stderr --test-reporter-destination=$out $in`;
+const command = `${node} --require "${hookRequire}" --import "data:text/javascript,${importCode}" $nodeArgs $in -- $args > $out`;
+const testCommand = `${node} --require "${hookRequire}" --import "data:text/javascript,${importCode}" --test --test-reporter=${testReporter} --test-reporter=tap --test-reporter-destination=stderr --test-reporter-destination=$out $nodeArgs $in -- $args`;
 
 /**
  * Create a rule in the specified `ninja` builder with the specified `name` that will
@@ -61,6 +61,7 @@ export function makeNodeRule(
   in: Input<string>;
   out: O;
   args?: string;
+  nodeArgs?: string;
   [implicitDeps]?: string | readonly string[];
   [orderOnlyDeps]?: string | readonly string[];
   [implicitOut]?: string | readonly string[];
@@ -74,6 +75,7 @@ export function makeNodeRule(
     depfile: "$out.depfile",
     deps: "gcc",
     args: "",
+    nodeArgs: "",
   });
 }
 
@@ -114,6 +116,7 @@ export function makeNodeTestRule(
   in: Input<string>;
   out: O;
   args?: string;
+  nodeArgs?: string;
   [implicitDeps]?: string | readonly string[];
   [orderOnlyDeps]?: string | readonly string[];
   [implicitOut]?: string | readonly string[];
@@ -127,5 +130,6 @@ export function makeNodeTestRule(
     depfile: "$out.depfile",
     deps: "gcc",
     args: "",
+    nodeArgs: "",
   });
 }


### PR DESCRIPTION
The `args` variable really should be used for command line arguments passed to the JavaScript file rather than command line arguments for node or v8.  node and v8 flags can now be passed with `nodeArgs`.