### PR TITLE
Remove `--` in `node` plugin

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -22,8 +22,8 @@ const importCode =
 // we mention `node.exe` with the file extension to avoid the `winpty node` alias.
 const node = platform() === "win32" ? "cmd /c node.exe" : "node";
 
-const command = `${node} --require "${hookRequire}" --import "data:text/javascript,${importCode}" $nodeArgs $in -- $args > $out`;
-const testCommand = `${node} --require "${hookRequire}" --import "data:text/javascript,${importCode}" --test --test-reporter=${testReporter} --test-reporter=tap --test-reporter-destination=stderr --test-reporter-destination=$out $nodeArgs $in -- $args`;
+const command = `${node} --require "${hookRequire}" --import "data:text/javascript,${importCode}" $nodeArgs $in $args > $out`;
+const testCommand = `${node} --require "${hookRequire}" --import "data:text/javascript,${importCode}" --test --test-reporter=${testReporter} --test-reporter=tap --test-reporter-destination=stderr --test-reporter-destination=$out $nodeArgs $in $args`;
 
 /**
  * Create a rule in the specified `ninja` builder with the specified `name` that will


### PR DESCRIPTION
Don't include `--` in the `node` plugin to distinguish between node arguments and our own arguments as these are passed into `argv` of our script.