### PR TITLE
Expose `makeFormatToRule` in `biome`

### DIFF
--- a/packages/biome/package.json
+++ b/packages/biome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A biome plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/biome/src/biome.test.ts
+++ b/packages/biome/src/biome.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import { strict as assert } from "node:assert";
-import { makeLintRule, makeFormatRule } from "./biome.js";
+import { makeLintRule, makeFormatRule, makeFormatToRule } from "./biome.js";
 import { NinjaBuilder, orderOnlyDeps } from "@ninjutsu-build/core";
 
 test("makeLintRule", () => {
@@ -28,6 +28,17 @@ test("makeFormatRule", () => {
     out[orderOnlyDeps],
     "$builddir/.ninjutsu-build/biome/format/bar.js",
   );
+});
+
+test("makeFormatToRule", () => {
+  const ninja = new NinjaBuilder();
+  const format = makeFormatToRule(ninja);
+  const out: "nice.js" = format({
+    in: "ugly.js",
+    out: "nice.js",
+    configPath: "biome.json",
+  });
+  assert.equal(out, "nice.js");
 });
 
 test("format then lint", () => {


### PR DESCRIPTION
Add a way to format files out-of-place.

When formatting source files the `makeFormatRule` will do the correct thing and format your files, while providing the correct build-order dependency for dependents.

However, when generating code from scripts, the `makeFormatRule` will format the generated file in-place and this will mess with the timestamp that `ninja` expects from the generated file.  This results in `ninja` always seeing the generated file as modified and will continue to rebuild all dependents.

The `makeFormatToRule` is suitable in this case for formatting generated files from a temporary directory to their final destination.