### PR TITLE
Fix `makeFormatToRule` for Windows paths

### DIFF
--- a/packages/biome/package.json
+++ b/packages/biome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "A biome plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
`type` cannot handle forward slashes in the path passed to it and requires backslashes.  In order to keep `ninjutsu-build`'s preference for forward slashes everywhere, we create an additional variable for Windows and pass in a copy of the `in` variable but using forward slashes.  The ninja manual recommends creating additional variables if you need a different version of `$in` (or `$out`).