### PR TITLE
Show as many CI failures as possible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,4 +24,4 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - run: npm ci
     - run: npm run configure
-    - run: ninja
+    - run: ninja -k 0


### PR DESCRIPTION
On pull requests we want to show as many failures as possible in one go in order to reduce the number of iteration cycles to fix issues. Running `ninja -k 0` will cause ninja to attempt to build as much as it can and not to stop early if it encounters an error.