### PR TITLE
Allow linting rule to inject validations

### DIFF
--- a/packages/biome/package-lock.json
+++ b/packages/biome/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.7.0",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/biome",
-      "version": "0.7.0",
+      "version": "0.7.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.6"
@@ -16,7 +16,7 @@
       },
       "peerDependencies": {
         "@biomejs/biome": "1.x",
-        "@ninjutsu-build/core": "^0.8.0"
+        "@ninjutsu-build/core": "^0.8.7"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.0.tgz",
-      "integrity": "sha512-ghFc9xYY6czyriOYU0dd0IAGihIPniI7AZOytlilarOZ+REH6d6/P5kCticGHq8D/muG1mZ7w+kKV4ItCeh9Mg==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.7.tgz",
+      "integrity": "sha512-piYq5zdY2aVKTO6oZFl8k/h0A140BMgDns+MHy71CYKF3KNt4AQFT7Q3S1I5Q0QoLNkzoBdgJfeaEzf7dlSk2A==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"

--- a/packages/biome/package.json
+++ b/packages/biome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "A biome plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "@biomejs/biome": "1.x",
-    "@ninjutsu-build/core": "^0.8.0"
+    "@ninjutsu-build/core": "^0.8.7"
   },
   "devDependencies": {
     "@types/node": "^20.10.6"

--- a/packages/biome/src/biome.test.ts
+++ b/packages/biome/src/biome.test.ts
@@ -1,16 +1,50 @@
 import test from "node:test";
 import { strict as assert } from "node:assert";
 import { makeLintRule, makeFormatRule, makeFormatToRule } from "./biome.js";
-import { NinjaBuilder, orderOnlyDeps } from "@ninjutsu-build/core";
+import {
+  NinjaBuilder,
+  implicitDeps,
+  orderOnlyDeps,
+  validations,
+} from "@ninjutsu-build/core";
 
 test("makeLintRule", () => {
   const ninja = new NinjaBuilder();
   const lint = makeLintRule(ninja);
-  const out: "$builddir/.ninjutsu-build/biome/lint/foo.js" = lint({
+  const out: {
+    file: "foo.js";
+    [validations]: "$builddir/.ninjutsu-build/biome/lint/foo.js";
+    [orderOnlyDeps]?: string | readonly string[];
+  } = lint({
     in: "foo.js",
     configPath: "biome.json",
   });
-  assert.equal(out, "$builddir/.ninjutsu-build/biome/lint/foo.js");
+  assert.deepEqual(out, {
+    file: "foo.js",
+    [validations]: "$builddir/.ninjutsu-build/biome/lint/foo.js",
+  });
+
+  const out2: {
+    file: "bar.js";
+    [validations]: "$builddir/.ninjutsu-build/biome/lint/bar.js";
+    [orderOnlyDeps]?: string | readonly string[];
+  } = lint({
+    in: {
+      file: "bar.js",
+      [implicitDeps]: ["implicitDeps"],
+      [orderOnlyDeps]: ["buildOrder"],
+      [validations]: ["validation"],
+    },
+    configPath: "biome.json",
+    [orderOnlyDeps]: ["moreBuildOrder"],
+  });
+
+  // Check we only pass through the `orderOnlyDeps` within `in`.
+  assert.deepEqual(out2, {
+    file: "bar.js",
+    [validations]: "$builddir/.ninjutsu-build/biome/lint/bar.js",
+    [orderOnlyDeps]: ["buildOrder"],
+  });
 });
 
 test("makeFormatRule", () => {
@@ -23,11 +57,10 @@ test("makeFormatRule", () => {
     in: "bar.js",
     configPath: "biome.json",
   });
-  assert.equal(out.file, "bar.js");
-  assert.equal(
-    out[orderOnlyDeps],
-    "$builddir/.ninjutsu-build/biome/format/bar.js",
-  );
+  assert.deepEqual(out, {
+    file: "bar.js",
+    [orderOnlyDeps]: "$builddir/.ninjutsu-build/biome/format/bar.js",
+  });
 });
 
 test("makeFormatToRule", () => {
@@ -46,11 +79,25 @@ test("format then lint", () => {
   const format = makeFormatRule(ninja);
   const lint = makeLintRule(ninja);
   const formatted = format({
-    in: "bar.js",
+    in: "src/bar.js",
     configPath: "biome.json",
   });
-  lint({
+  assert.deepEqual(formatted, {
+    file: "src/bar.js",
+    [orderOnlyDeps]: "$builddir/.ninjutsu-build/biome/format/src/bar.js",
+  });
+
+  const linted = lint({
     in: formatted,
     configPath: "biome.json",
+  });
+
+  // Check anything that would take `linted` as an input would wait for
+  // formatting to finish (orderOnlyDeps) and guarantee that linting would
+  // be done (validations).
+  assert.deepEqual(linted, {
+    file: "src/bar.js",
+    [validations]: "$builddir/.ninjutsu-build/biome/lint/src/bar.js",
+    [orderOnlyDeps]: "$builddir/.ninjutsu-build/biome/format/src/bar.js",
   });
 });


### PR DESCRIPTION
If we would like to lint a source `index.js`, it means that we require users of `ninjutsu-build` to put a `validations` step on any build edge that used `index.js` as an input.

After a recent change to `@ninjutsu-build/core` we can return an `Input<string>` object from linting rules that have a built-in `validations` step for all consumers of this value.

This means that users do not need to remember to put a `validations` property on all users of `index.js`, instead they can pass `index.js` through the linting rule and then pass the returned value into any dependent rules.

This should make everything simpler and reduce mistakes and the burden of knowledge for users.