### PR TITLE
Use the new linting rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.4.0",
-        "@ninjutsu-build/biome": "^0.7.0",
+        "@ninjutsu-build/biome": "^0.8.0",
         "@ninjutsu-build/bun": "^0.1.0",
         "@ninjutsu-build/core": "^0.8.5",
         "@ninjutsu-build/node": "^0.8.0",
@@ -206,16 +206,16 @@
       }
     },
     "node_modules/@ninjutsu-build/biome": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/biome/-/biome-0.7.0.tgz",
-      "integrity": "sha512-eV3eie+hpk3aGMxioM1JdOYMLmaJYLHlwTdj2fm/OcYptMhUlRsPtKR9FLfrBks3GGK9tKoPr2e510sWXEFTCg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/biome/-/biome-0.8.0.tgz",
+      "integrity": "sha512-j8wJWOGqP3/amS6c60rliHxzYmB9UF94JuLwuw4Sy0FFiyJTp8Uw4/265j9sSFr0X8j6/5GkibyVSCT3RjyXrg==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@biomejs/biome": "1.x",
-        "@ninjutsu-build/core": "^0.8.0"
+        "@ninjutsu-build/core": "^0.8.7"
       }
     },
     "node_modules/@ninjutsu-build/bun": {
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.5.tgz",
-      "integrity": "sha512-iswKbkfoxEeHSJqktsf42Xc2uaJotDrI7+z49ThEwUNsJH/c+7b0q0A2XO0O0UxbBMQy+k8cbmrahDQ1Ioq6iQ==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.7.tgz",
+      "integrity": "sha512-piYq5zdY2aVKTO6oZFl8k/h0A140BMgDns+MHy71CYKF3KNt4AQFT7Q3S1I5Q0QoLNkzoBdgJfeaEzf7dlSk2A==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "1.4.0",
-    "@ninjutsu-build/biome": "^0.7.0",
+    "@ninjutsu-build/biome": "^0.8.0",
     "@ninjutsu-build/bun": "^0.1.0",
     "@ninjutsu-build/core": "^0.8.5",
     "@ninjutsu-build/node": "^0.8.0",


### PR DESCRIPTION
Use the new linting rule and the fact that it injects a `validations` step into any dependent build edges to avoid manually passing a `validations` property.

We also do not need the `cwd` property (for a long time!) and the order-only dependencies aren't needed as we install `biome` at the top level instead of per-package and it's installed before `configure.mjs` is ever ran.