### PR TITLE
Add `makeCheckFormattedRule` to `@ninjutsu-build/biome`

### DIFF
--- a/packages/biome/package-lock.json
+++ b/packages/biome/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.7.5",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/biome",
-      "version": "0.7.5",
+      "version": "0.8.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.6"

--- a/packages/biome/package.json
+++ b/packages/biome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A biome plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
With the new idiom of static analysis rules being able to return `validations` to add into the dependent edges, we write `makeCheckFormattedRule` to do a non-destructive check that the files are correctly formatted.

We will conditionally use this in our `configure.mjs` for CI as right now if we submit a file that is incorrectly formatted the CI will just fix it (in the temporary workspace) and continue without reporting the issue.