### PR TITLE
Convert `makeTypeCheckRule` to new validation format

### DIFF
--- a/packages/tsc/package-lock.json
+++ b/packages/tsc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/tsc",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.2.2"

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/tsc/src/tsc.test.ts
+++ b/packages/tsc/src/tsc.test.ts
@@ -95,14 +95,23 @@ test("makeTSCRule", () => {
 test("makeTypeCheckRule", () => {
   const ninja = new NinjaBuilder();
   const typecheck = makeTypeCheckRule(ninja);
-  assert.equal(
+  assert.deepEqual(
     typecheck({
-      in: ["src/common/index.ts"],
+      in: ["src/common/index.ts", "src/app/index.ts"],
       out: "$builddir/typechecked.stamp",
       compilerOptions: {
         outDir: "output",
       },
     }),
-    "$builddir/typechecked.stamp",
+    [
+      {
+        file: "src/common/index.ts",
+        [validations]: "$builddir/typechecked.stamp",
+      },
+      {
+        file: "src/app/index.ts",
+        [validations]: "$builddir/typechecked.stamp",
+      },
+    ],
   );
 });


### PR DESCRIPTION
Instead of require developers to manually put in a `validations` property for build edges, we instead return an augmented object from the type check rule that can then be seemlessly passed into other rules.