### PR TITLE
Use `typecheck` rule in `configure.mjs`

### DIFF
--- a/configure.mjs
+++ b/configure.mjs
@@ -288,7 +288,7 @@ toposort(
     // Type check all the tests
     const testTargets = (() => {
       if (tests.length !== 0) {
-        const typechecked = typecheck({
+        return typecheck({
           in: tests,
           out: join(cwd, "dist", "typechecked.stamp"),
           compilerOptions,
@@ -297,15 +297,11 @@ toposort(
           // Only run this after generating all the TypeScript definition files for the
           // library files.
           [orderOnlyDeps]: dist,
-        });
-
-        // Individually transpile and run each test
-        return tests.map((t) => {
+        }).map((t) => {
           const file = getInput(t);
           const js = transpile({
             in: t,
             out: join(cwd, "dist", basename(file, extname(file)) + ".mjs"),
-            [validations]: () => typechecked,
             args: transpileArgs,
           });
           return test({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ninjutsu-build/bun": "^0.1.0",
         "@ninjutsu-build/core": "^0.8.5",
         "@ninjutsu-build/node": "^0.8.0",
-        "@ninjutsu-build/tsc": "^0.10.5",
+        "@ninjutsu-build/tsc": "^0.11.1",
         "@types/toposort": "^2.0.7",
         "glob": "^10.3.10",
         "swc": "^1.0.11",
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@ninjutsu-build/tsc": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/tsc/-/tsc-0.10.5.tgz",
-      "integrity": "sha512-3nzAikZgA7zBR3ZRe3HKw5kqQ1XdPqjUnvKTmvI6Um3XLnTJ5wEt/UnpxF8qjthmYGTe7raS6uGzc7zhV0a/kA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/tsc/-/tsc-0.11.1.tgz",
+      "integrity": "sha512-8GiD6qLqKtssArhDFxS33faqB2CO0ZHb8GAS0DRHZZqqFXheAB1ZSEojZW1vBTBNO6J8wmXO4ov8tqKyyPRZWw==",
       "dev": true,
       "dependencies": {
         "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@ninjutsu-build/bun": "^0.1.0",
     "@ninjutsu-build/core": "^0.8.5",
     "@ninjutsu-build/node": "^0.8.0",
-    "@ninjutsu-build/tsc": "^0.10.5",
+    "@ninjutsu-build/tsc": "^0.11.1",
     "@types/toposort": "^2.0.7",
     "glob": "^10.3.10",
     "swc": "^1.0.11",


### PR DESCRIPTION
Use the fact that the new `typecheck` rule will return an object carrying the validation with it so it can be forwarded into dependent rules without having to manually specify the `validations` property.

This should have no effect on the `build.ninja` file.