### PR TITLE
Fix missing `.mts` file

### DIFF
--- a/configure.mjs
+++ b/configure.mjs
@@ -259,7 +259,7 @@ toposort(
         : dependenciesInstalled;
 
     // Grab all TypeScript source files and format them
-    const ts = globSync(join(cwd, "src", "*.ts"), {
+    const ts = globSync(join(cwd, "src", "*.{mts,ts}"), {
       posix: true,
       ignore: { ignored: (f) => f.name.endsWith(".test.ts") },
     }).map(formatAndLint);


### PR DESCRIPTION
When refactoring the configuration file we missed compiling the `runTSC.mts` TypeScript file, which caused a published version of `@ninjutsu-build/tsc` to not work.

Future work is planned to add back integration tests to catch issues like this happening.