### PR TITLE
Add tests for symlinks in `@ninjutsu-build/node`

### DIFF
--- a/integration/src/util.mjs
+++ b/integration/src/util.mjs
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 
-export function getDeps(cwd ) {
+export function getDeps(cwd) {
   const deps = {};
   let name = "";
   for (const line of execSync("ninja -t deps", { cwd })


### PR DESCRIPTION
Ensure that the paths written to the `dyndeps` file for the node rule refers to the canonical path for files, even if they are symlinked.

We would like to guarantee this behaviour because it should simplify the use case when using workspaces and we symlink our own packages to `node_modules` directories.

Today in `@ninjutsu-build` we build ourselves by constructing a `tgz` file and then `npm install`ing it for the appropriate dependent packages.  This is slower than what we can achieve with workspaces and it also breaks the dependencies and requires use to use implicit dependencies rather than order-only dependencies.

If we can guarantee this behaviour then dependent packages only need an order-only dependency that their dependencies are intially ready, then the node rule will generate `dyndeps` on the files in their original position and all works out.

This will need to be done with other packages who are generating `dyndeps`, such as `tsc` and `esbuild`.