### PR TITLE
Run all matrix configurations on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node: [lts/-1, lts/*, latest]


### PR DESCRIPTION
The pull request for adding the `@ninjutsu-build/esbuild` plugin was failing on Ubuntu and then stopping all other jobs.  If they would have continued then we would have seen that the Windows ones would have succeeded and this would have been useful information to diagnose the issue.

Right now our CI checks only take 30s-60s to complete so there is very little lost in always running each job until failure.