### PR TITLE
Make path to `tsc` more resilient

### DIFF
--- a/integration/src/tsc.test.mts
+++ b/integration/src/tsc.test.mts
@@ -1,0 +1,141 @@
+import { beforeEach, test, describe } from "node:test";
+import { strict as assert } from "node:assert";
+import { writeFileSync } from "node:fs";
+import { NinjaBuilder } from "@ninjutsu-build/core";
+import { makeTSCRule } from "@ninjutsu-build/tsc";
+import { mkdirSync, rmSync, symlinkSync, existsSync } from "node:fs";
+import { execSync, spawnSync } from "node:child_process";
+import { join } from "node:path/posix";
+import { getDeps } from "./util.mjs";
+
+const dir = join("integration", "staging", "tsc");
+
+const compilerOptions = {
+  outDir: "dist",
+  declaration: true,
+  strict: true,
+  alwaysStrict: true,
+  skipLibCheck: true,
+};
+
+describe("tsc tests", () => {
+  beforeEach(() => {
+    rmSync(dir, { force: true, recursive: true });
+    mkdirSync(dir);
+  });
+
+  test("Basic example", () => {
+    const negate = "negate.mts";
+    writeFileSync(
+      join(dir, negate),
+      "export function negate(n: number): number { return -n; }\n",
+    );
+
+    const add = "add.cts";
+    writeFileSync(
+      join(dir, add),
+      "export function add(a: number, b: number): number { return a + b; }\n",
+    );
+
+    // `subtract` will be the "real" path to `subtract.cjs` and we will reference it
+    // through an symlinked directory and expect that that dynamic dependencies
+    // will refer to the canonical path
+    const subtract = (() => {
+      const impDir = join(dir, "imp");
+      mkdirSync(impDir);
+      const subtract = "subtract.cts";
+      writeFileSync(
+        join(impDir, subtract),
+        "export function subtract(a: number, b: number): number { return a - b; }\n",
+      );
+      const srcDir = join(dir, "src");
+      // Use a "junction" to avoid admin requirements on windows
+      // https://github.com/nodejs/node/issues/18518
+      symlinkSync(
+        // Junction links require absolute
+        join(process.cwd(), impDir),
+        join(process.cwd(), srcDir),
+        "junction",
+      );
+      return "imp/" + subtract;
+    })();
+    assert.strictEqual(subtract, "imp/subtract.cts");
+
+    const script = "script.mts";
+    writeFileSync(
+      join(dir, script),
+      "import { negate } from './negate.mjs';\n" +
+        "import { add } from './add.cjs';\n" +
+        "import { subtract } from './src/subtract.cjs';\n" +
+        "console.log(negate(1));\n" +
+        "console.log(add(2, 3));\n" +
+        "console.log(subtract(4, 5));\n",
+    );
+
+    const script2 = "script.cts";
+    writeFileSync(
+      join(dir, script2),
+      "const { add } = require('./add.cjs');\n" +
+        "const { subtract } = require('./src/subtract.cjs');\n" +
+        "console.log(add(2, 3));\n" +
+        "console.log(subtract(4, 5));\n",
+    );
+
+    const ninja = new NinjaBuilder({}, dir);
+    const tsc = makeTSCRule(ninja);
+    const output = tsc({ in: [script], compilerOptions });
+    const output2 = tsc({ in: [script2], compilerOptions });
+    writeFileSync(join(dir, "build.ninja"), ninja.output);
+
+    {
+      const { stdout, stderr, status } = spawnSync(
+        "ninja",
+        ["-d", "keepdepfile"],
+        { cwd: dir },
+      );
+      const stdoutStr = stdout.toString();
+      assert.strictEqual(stderr.toString(), "");
+      assert.strictEqual(status, 0, stdoutStr);
+      assert.match(stdoutStr, /Compiling script.mts/);
+      assert.match(stdoutStr, /Compiling script.cts/);
+    }
+
+    for (const out of [...output, ...output2]) {
+      assert.strictEqual(existsSync(join(dir, out)), true);
+    }
+
+    assert.strictEqual(
+      execSync("ninja", { cwd: dir }).toString().trim(),
+      "ninja: no work to do.",
+    );
+    const deps = getDeps(dir);
+    assert.deepEqual(
+      new Set(Object.keys(deps)),
+      new Set([...output, ...output2]),
+    );
+    for (const out of output) {
+      assert.notStrictEqual(deps[out].indexOf(negate), -1, `Missing ${negate}`);
+      assert.notStrictEqual(deps[out].indexOf(add), -1, `Missing ${add}`);
+      // TODO: Change this to `subtract` and have a dependency on the canonical
+      // file rather than the symlink path
+      assert.notStrictEqual(
+        deps[out].indexOf("src/subtract.cts"),
+        -1,
+        "Missing src/subtract.cts",
+      );
+    }
+
+    // TODO: `script.cts` is **missing** all of the dependencies we would
+    // expect and this needs to be fixed
+    for (const out of output2) {
+      assert.strictEqual(deps[out].indexOf(add), -1, `Missing ${add}`);
+      assert.strictEqual(
+        deps[out].indexOf("src/subtract.cts"),
+        -1,
+        "Missing src/subtract.cts",
+      );
+    }
+  });
+
+  // TODO: Check the `incremental` flag works correctly
+});

--- a/packages/tsc/package-lock.json
+++ b/packages/tsc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/tsc",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.2.2"
@@ -18,13 +18,13 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.0"
+        "@ninjutsu-build/core": "^0.8.8"
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.0.tgz",
-      "integrity": "sha512-ghFc9xYY6czyriOYU0dd0IAGihIPniI7AZOytlilarOZ+REH6d6/P5kCticGHq8D/muG1mZ7w+kKV4ItCeh9Mg==",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.8.tgz",
+      "integrity": "sha512-3bp/9Zi7Uxb8Du/LfbJhzEYypT2zMW87gflPLpcS5AQe6Ha8KXi20kNokzwFwprexKPXKc55Z9edkKaLMImcJw==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {
@@ -33,7 +33,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@ninjutsu-build/core": "^0.8.0"
+    "@ninjutsu-build/core": "^0.8.8"
   },
   "devDependencies": {
     "@types/node": "^20.9.0"

--- a/packages/tsc/src/runTSC.mts
+++ b/packages/tsc/src/runTSC.mts
@@ -92,7 +92,9 @@ async function run(): Promise<void> {
           : path;
       };
       for (const line of lines) {
-        deps += " " + makeRelative(line).replaceAll("\\", "/").trim();
+        if (line !== "") {
+          deps += " " + makeRelative(line).replaceAll("\\", "/").trim();
+        }
       }
 
       writeFileSync(depfile, deps);

--- a/packages/tsc/src/tsc.ts
+++ b/packages/tsc/src/tsc.ts
@@ -19,6 +19,17 @@ import ts from "typescript";
 import { platform } from "os";
 import { join } from "node:path";
 import { relative } from "node:path/posix";
+import {
+  relative as relativeNative,
+  resolve as resolveNative,
+} from "node:path";
+
+function getRunTSCPath(ninja: NinjaBuilder): string {
+  return relativeNative(
+    resolveNative(process.cwd(), ninja.outputDir),
+    require.resolve(join("@ninjutsu-build", "tsc", "dist", "runTSC.mjs")),
+  );
+}
 
 function compilerOptionToArray(
   name: string,
@@ -120,7 +131,9 @@ export function makeTypeCheckRule(
   const typecheck = ninja.rule(name, {
     command:
       prefix +
-      "node node_modules/@ninjutsu-build/tsc/dist/runTSC.mjs --cwd $cwd --touch $out --out $out --depfile $out.depfile --listFiles --noEmit $args -- $in",
+      `node ${getRunTSCPath(
+        ninja,
+      )} --cwd $cwd --touch $out --out $out --depfile $out.depfile --listFiles --noEmit $args -- $in`,
     description: "Typechecking $in",
     in: needs<readonly Input<string>[]>(),
     out: needs<string>(),
@@ -230,7 +243,9 @@ export function makeTSCRule(
   const tsc = ninja.rule(name, {
     command:
       prefix +
-      "node node_modules/@ninjutsu-build/tsc/dist/runTSC.mjs --cwd $cwd --out $out --depfile $out.depfile --listFiles $args -- $in",
+      `node ${getRunTSCPath(
+        ninja,
+      )} --cwd $cwd --out $out --depfile $out.depfile --listFiles $args -- $in`,
     description: "Compiling $in",
     depfile: "$out.depfile",
     deps: "gcc",


### PR DESCRIPTION
Use the new `outputDir` property in `NinjaBuilder` to create the path to `runTSC.mjs`.  This will allow us to use `@ninjutsu-build/tsc` from a different directory than the project root to store the configuration script and `package.json`.

Write an integration test for `@ninjutsu-build/tsc` as this uses a vastly different directory structure and will check whether we resolved the correct path.

The integration test revealed issues with incorrect `dyndeps` being created, namely:

  * a dependency to `"."`, which causes `ninja` to have to do work when run a second time - this has been fixed
  * missing dependencies for CommonJS files being transpiled - this has not been fixed
  * symlinks are reported by `--listFiles` rather than the canonical paths - this needs to be fixed for our end goal of supporting symlinks for workspaces