### PR TITLE
Make path to `@ninjutsu-build/node` scripts more resilient

### DIFF
--- a/integration/src/node.test.mts
+++ b/integration/src/node.test.mts
@@ -60,7 +60,7 @@ describe("node tests", () => {
         "console.log(two + ' + 1 = ' + three);\n",
     );
 
-    const ninja = new NinjaBuilder();
+    const ninja = new NinjaBuilder({}, dir);
     const node = makeNodeRule(ninja);
     const output = node({ in: script, out: "output.txt" });
     const output2 = node({ in: script2, out: "output2.txt" });

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.8.0",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/node",
-      "version": "0.8.0",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.9.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
Use the new `outputDir` property in `NinjaBuilder` to create the path to the JavaScript files we inject into `node`.  This will allow us to use `@ninjutsu-build/node` from a different directory than the project root to store the configuration script and `package.json`.

This was not discovered in the integration test for `node` since `node` itself will walk up the tree to find the nearest `node_modules` and that one was in `integration/staging` and contained the `@ninjutsu-build/node` installation.

Add a unit test for the `makeNodeTestRule` to make sure we have correctly resolved the test reporter.

After this change the files injected will be relative paths and this will disable the `node_modules` resolution so the integration test will now catch errors if we resolved it incorrectly.  Note that we need to use forward slashes to be understood by `node`, which is why there is a `replaceAll` function call.