### PR TITLE
Fix relative import links for node rule

### DIFF
--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/node",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.9.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -12,12 +12,17 @@ import {
   relative as relativeNative,
   resolve as resolveNative,
 } from "node:path";
+import { isAbsolute } from "node:path/posix";
 
 function resolvePath(ninja: NinjaBuilder, file: string): string {
-  return relativeNative(
+  const path = relativeNative(
     resolveNative(process.cwd(), ninja.outputDir),
     require.resolve(file),
   ).replaceAll("\\", "/");
+  // Make sure that relative paths start with "./" or "../" as node
+  // will resolve "foo/bar.js" as "node_modules/foo/bar.js" instead
+  // of "./foo/bar.js".
+  return !isAbsolute(path) && !path.startsWith("../") ? "./" + path : path;
 }
 
 function getImportCode(ninja: NinjaBuilder): string {


### PR DESCRIPTION
When the relative path is a subdirectory we need to make sure that the import paths to `node` start with `"./"` otherwise `node` will interpret this as a package found inside `node_modules` and not a relative path.