### PR TITLE
Fix current working directory within `@ninjutsu-build/tsc`

### DIFF
--- a/packages/tsc/package-lock.json
+++ b/packages/tsc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/tsc",
-      "version": "0.11.2",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.2.2"

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
Avoid using `cd cwd && npx tsc` inside `runTSC.mts` because this requires the installation of `tsc` to be in a parent `node_modules` directory.  Instead we pass the relative path to `tsc` to `runTSC.mjs` and use this.

Because we no longer `cd`ing into a directory we don't have to fixup the input and output files inside `makeTSCRule` by getting relative paths.

Additionally we don't resolve the full path
`@ninjutsu-build/tsc/dist/runTSC.mjs` instead resolve to `./runTSC.mjs` because this allows us to correctly resolve the local version of `./runTSC.mjs` when running the unit tests.  Today we are actually resolving the installation in a parent directory, which is made obvious when trying to move the configure script to a subdirectory.