### PR TITLE
Fix internal references in `@ninjutsu-build/node`

### DIFF
--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/node",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.9.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
Don't resolve the full path `@ninjutsu-build/node/foo.js` and instead resolve `./foo.js` because this allows us to correctly resolve the local version when running the unit tests.  Today we are actually resolving the installation in a parent directory, which is made obvious when trying to move the configure script to a subdirectory.