### PR TITLE
Use `is-ci` instead of custom flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,5 +24,5 @@ jobs:
         cache: 'npm'
     - uses: seanmiddleditch/gha-setup-ninja@master
     - run: npm ci --prefix configure
-    - run: npm run configure -- --ci
+    - run: npm run configure
     - run: ninja -k 0

--- a/configure/configure.mjs
+++ b/configure/configure.mjs
@@ -13,14 +13,7 @@ import {
   makeLintRule,
 } from "@ninjutsu-build/biome";
 import { makeTranspileRule } from "@ninjutsu-build/bun";
-import {
-  basename,
-  dirname,
-  extname,
-  relative,
-  resolve,
-  join,
-} from "node:path/posix";
+import { basename, dirname, extname, relative, join } from "node:path/posix";
 import {
   resolve as resolveNative,
   relative as relativeNative,
@@ -31,6 +24,11 @@ import { fileURLToPath } from "node:url";
 import { globSync } from "glob";
 import { platform } from "os";
 import toposort from "toposort";
+import isCi from "is-ci";
+
+if (isCi) {
+  console.log("Running in CI mode");
+}
 
 const extLookup = {
   ".ts": ".js",
@@ -42,7 +40,6 @@ const touch = platform() == "win32" ? "type NUL > $out" : "touch $out";
 const prefix = platform() === "win32" ? "cmd /c " : "";
 
 const useBun = process.argv.includes("--bun");
-const inCi = process.argv.includes("--ci");
 
 function makeNpmCiRule(ninja) {
   const ci = ninja.rule("npmci", {
@@ -223,7 +220,7 @@ const typecheck = inject(makeTypeCheckRule(ninja), {
 });
 const test = makeNodeTestRule(ninja);
 const tar = makeTarRule(ninja);
-const format = inCi
+const format = isCi
   ? checkFormatted
   : addBiomeConfig(
       inject(makeFormatRule(ninja), {

--- a/configure/package-lock.json
+++ b/configure/package-lock.json
@@ -18,6 +18,7 @@
         "@types/node": "^20.12.7",
         "@types/toposort": "^2.0.7",
         "glob": "^10.3.10",
+        "is-ci": "^3.0.1",
         "toposort": "^2.0.2"
       }
     },
@@ -860,6 +861,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -1359,6 +1375,18 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",

--- a/configure/package.json
+++ b/configure/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^20.12.7",
     "@types/toposort": "^2.0.7",
     "glob": "^10.3.10",
+    "is-ci": "^3.0.1",
     "toposort": "^2.0.2"
   }
 }


### PR DESCRIPTION
It seems reasonably common to use the `is-ci` package to determine whether we are running in a `CI` environment.