### PR TITLE
Change `@ninjutsu-build/tsc` to resolve symlinks for `dyndep`

### DIFF
--- a/integration/src/tsc.test.mts
+++ b/integration/src/tsc.test.mts
@@ -59,7 +59,6 @@ describe("tsc tests", () => {
       );
       return "imp/" + subtract;
     })();
-    assert.strictEqual(subtract, "imp/subtract.cts");
 
     const script = "script.mts";
     writeFileSync(
@@ -118,12 +117,10 @@ describe("tsc tests", () => {
     for (const out of output) {
       assert.notStrictEqual(deps[out].indexOf(negate), -1, `Missing ${negate}`);
       assert.notStrictEqual(deps[out].indexOf(add), -1, `Missing ${add}`);
-      // TODO: Change this to `subtract` and have a dependency on the canonical
-      // file rather than the symlink path
       assert.notStrictEqual(
-        deps[out].indexOf("src/subtract.cts"),
+        deps[out].indexOf(subtract),
         -1,
-        "Missing src/subtract.cts",
+        `Missing ${subtract}`,
       );
     }
 
@@ -136,9 +133,9 @@ describe("tsc tests", () => {
         `${add} should be missing`,
       );
       assert.strictEqual(
-        deps[out].indexOf("src/subtract.cts"),
+        deps[out].indexOf(subtract),
         -1,
-        "src/subtract.cts should be missing",
+        `${subtract} should be missing`,
       );
     }
   });

--- a/packages/tsc/package-lock.json
+++ b/packages/tsc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/tsc",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.2.2"

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
If we can have all plugins emit the canonical path (if it exists) for dynamic dependencies (e.g. follow symlinks) then this allows us to move closer to supporting monorepos and workspace workflows.  Since if we symlink packages into `node_modules` we will emit dynamic dependencies on the original locations.