### PR TITLE
Widen the type passed to `orderOnlyDeps`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,6 @@ jobs:
         node-version: ${{ matrix.node }}
         cache: 'npm'
     - uses: seanmiddleditch/gha-setup-ninja@master
-    - run: npm ci --prefix configure
+    - run: cd configure && npm ci
     - run: npm run configure
     - run: ninja -k 0

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/core",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/core",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "MIT",
       "devDependencies": {
         "tsafe": "^1.6.6"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/core",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Easily create ninja build files with this TypeScript library (https://ninja-build.org/)",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -290,6 +290,7 @@ test("Passing all arguments to a `NinjaRule`", () => {
     in: needs<Input<string>>(),
     command: "[command]",
     description: "[desc]",
+    [orderOnlyDeps]: ["oA", { file: "unused", [orderOnlyDeps]: "oB" }],
   });
   const out: "out.txt" = all({
     out: "out.txt",
@@ -299,7 +300,10 @@ test("Passing all arguments to a `NinjaRule`", () => {
     description: "description_",
     [implicitDeps]: "implicitDeps_",
     [implicitOut]: ["implicitOut_"],
-    [orderOnlyDeps]: ["orderOnlyDeps_"],
+    [orderOnlyDeps]: [
+      "orderOnlyDeps_A",
+      { file: "unused", [orderOnlyDeps]: "orderOnlyDeps_B" },
+    ],
     [validations]: (out) => ["validations_" + out],
     pool: "pool",
     extra: 123,
@@ -313,7 +317,7 @@ test("Passing all arguments to a `NinjaRule`", () => {
       [validations]: ["valid1"],
     },
     [implicitDeps]: "implicit2",
-    [orderOnlyDeps]: ["ordered2", "ordered3"],
+    [orderOnlyDeps]: ["ordered2", { file: "ordered3" }],
     [validations]: (out: string) => "valid2_" + out,
   });
   assert.equal(out, "out.txt");
@@ -322,13 +326,13 @@ test("Passing all arguments to a `NinjaRule`", () => {
     `rule all
   command = [command]
   description = [desc]
-build out.txt | implicitOut_: all in.txt | implicitDeps_ || orderOnlyDeps_ |@ validations_out.txt
+build out.txt | implicitOut_: all in.txt | implicitDeps_ || oA oB orderOnlyDeps_A orderOnlyDeps_B |@ validations_out.txt
   dyndep = dyndep_
   command = command_
   description = description_
   pool = pool
   extra = 123
-build foo: all hi | implicit1 implicit2 || ordered1 ordered2 ordered3 |@ valid1 valid2_foo
+build foo: all hi | implicit1 implicit2 || oA oB ordered1 ordered2 ordered3 |@ valid1 valid2_foo
 `,
   );
 });


### PR DESCRIPTION
In our `configure.mjs` file there are several places where we need to pass the result of a formatted/linted/typechecked file into the build-order dependencies of another rule.  This looks like:

```ts
const formatted = js.map((file) => format({ in: file });
const output = node({
    in: "entry.mjs",
    out: "results.txt",
    [orderOnlyDeps]: formatted,
});
```

However this won't work because `formatted` is
`{ file: string, [orderOnlyDeps]: string }` instead of `string | readonly string[]` which is accepted by `[orderOnlyDeps]`.  Instead we need to manually map to that property,

```ts
const formatted = js.map((file) => format({ in: file });
const output = node({
    in: "entry.mjs",
    out: "results.txt",
    [orderOnlyDeps]: formatted.map((file) => file[orderOnlyDeps]),
});
```

This again will break if we swap out `format` at runtime (e.g. within CI) from `makeFormatRule` to `makeCheckFormattedRule`, which returns a `{ file: string, [validations]: string }`.

So instead we widen the contract for `[orderOnlyDeps]` to accept `Input<string> | readonly Input<string>[]` and take the `[orderOnlyDeps]` property if it exists, otherwise take `file`.

I am unsure if we need to inject the `[validations]` from any object passed to `[orderOnlyDeps]` at the moment and whether it makes sense.