### PR TITLE
Disable window-latest/node-latest for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node: [lts/-1, lts/*, latest]
+        exclude:
+          - os: windows-latest # There is currently an external issue with this combo
+            node: latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This is failing now on `main` through no changes to our code:

```
Run cd configure && npm ci
node:internal/modules/cjs/loader:1205
  throw err;
  ^

Error: Cannot find module 'C:\npm\prefix\node_modules\npm\bin\npm-cli.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1202:15)
    at Module._load (node:internal/modules/cjs/loader:1027:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:187:14)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v22.0.0
Error: Process completed with exit code 1.
```

A separate pull request will be opened to reintroduce this check and it will be merged when the underlying issue is fixed.

An alternative would be to make the check non-mandatory on GitHub, but I feel it is much more understandable and inviting to contributors if all their checks can go green and we can see that `main` is passing all (valid) CI.