### PR TITLE
Widen the `orderOnlyDeps` type in plugins

### DIFF
--- a/packages/biome/package-lock.json
+++ b/packages/biome/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/biome",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@biomejs/biome": "1.x",
-        "@ninjutsu-build/core": "^0.8.7"
+        "@ninjutsu-build/core": "^0.8.9"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.7.tgz",
-      "integrity": "sha512-piYq5zdY2aVKTO6oZFl8k/h0A140BMgDns+MHy71CYKF3KNt4AQFT7Q3S1I5Q0QoLNkzoBdgJfeaEzf7dlSk2A==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.9.tgz",
+      "integrity": "sha512-+PhAtaz0kMl/oMf+JN9NDZtpgN208WRwt5gTJsAN4fcwVRAlsaPxun3PBVIT7hJXZ2PW2IQ4VYretvNWta6pFA==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"

--- a/packages/biome/package.json
+++ b/packages/biome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A biome plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {
@@ -23,6 +23,6 @@
   },
   "peerDependencies": {
     "@biomejs/biome": "1.x",
-    "@ninjutsu-build/core": "^0.8.7"
+    "@ninjutsu-build/core": "^0.8.9"
   }
 }

--- a/packages/biome/src/biome.ts
+++ b/packages/biome/src/biome.ts
@@ -81,7 +81,7 @@ export function makeFormatRule(
   configPath: string;
   args?: string;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: {
     file: string;
@@ -107,7 +107,7 @@ export function makeFormatRule(
     configPath: string;
     args?: string;
     [implicitDeps]?: string | readonly string[];
-    [orderOnlyDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
     [implicitOut]?: string | readonly string[];
     [validations]?: (out: {
       file: string;
@@ -189,7 +189,7 @@ export function makeFormatToRule(
   configPath: string;
   args?: string;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: string) => string | readonly string[];
 }) => O {
@@ -213,7 +213,7 @@ export function makeFormatToRule(
     configPath: string;
     args?: string;
     [implicitDeps]?: string | readonly string[];
-    [orderOnlyDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
     [implicitOut]?: string | readonly string[];
     [validations]?: (out: string) => string | readonly string[];
   }): O => {
@@ -290,7 +290,7 @@ export function makeCheckFormattedRule(
   configPath: string;
   args?: string;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: string) => string | readonly string[];
 }) => {
@@ -314,7 +314,7 @@ export function makeCheckFormattedRule(
     configPath: string;
     args?: string;
     [implicitDeps]?: string | readonly string[];
-    [orderOnlyDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
     [implicitOut]?: string | readonly string[];
     [validations]?: (out: string) => string | readonly string[];
   }): {
@@ -422,7 +422,7 @@ export function makeLintRule(
   configPath: string;
   args?: string;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: string) => string | readonly string[];
 }) => {
@@ -446,7 +446,7 @@ export function makeLintRule(
     configPath: string;
     args?: string;
     [implicitDeps]?: string | readonly string[];
-    [orderOnlyDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
     [implicitOut]?: string | readonly string[];
     [validations]?: (out: string) => string | readonly string[];
   }): {

--- a/packages/bun/package-lock.json
+++ b/packages/bun/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "@ninjutsu-build/bun",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/bun",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.2"
+        "@ninjutsu-build/core": "^0.8.9"
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.2.tgz",
-      "integrity": "sha512-mQhutAJt2znWKl2N4TrFcmv2h3cpnkOnXT/PTXA9LXjgsruIgRnQP5rSp3brZTavanPjtPmXOga45uv3e7UTSQ==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.9.tgz",
+      "integrity": "sha512-+PhAtaz0kMl/oMf+JN9NDZtpgN208WRwt5gTJsAN4fcwVRAlsaPxun3PBVIT7hJXZ2PW2IQ4VYretvNWta6pFA==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/bun",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A bun plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {
@@ -22,6 +22,6 @@
     "url": "https://github.com/elliotgoodrich/ninjutsu-build/issues"
   },
   "peerDependencies": {
-    "@ninjutsu-build/core": "^0.8.2"
+    "@ninjutsu-build/core": "^0.8.9"
   }
 }

--- a/packages/bun/src/bun.ts
+++ b/packages/bun/src/bun.ts
@@ -51,7 +51,7 @@ export function makeTranspileRule(
   out: O;
   args?: string;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: string) => string | readonly string[];
 }) => O {

--- a/packages/esbuild/package-lock.json
+++ b/packages/esbuild/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@ninjutsu-build/esbuild",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/esbuild",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.8",
+        "@ninjutsu-build/core": "^0.8.9",
         "esbuild": "^0.20.2",
         "node-jq": "^4.3.1"
       }
@@ -401,9 +401,9 @@
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.8.tgz",
-      "integrity": "sha512-3bp/9Zi7Uxb8Du/LfbJhzEYypT2zMW87gflPLpcS5AQe6Ha8KXi20kNokzwFwprexKPXKc55Z9edkKaLMImcJw==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.9.tgz",
+      "integrity": "sha512-+PhAtaz0kMl/oMf+JN9NDZtpgN208WRwt5gTJsAN4fcwVRAlsaPxun3PBVIT7hJXZ2PW2IQ4VYretvNWta6pFA==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/esbuild",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An esbuild plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {
@@ -22,7 +22,7 @@
     "url": "https://github.com/elliotgoodrich/ninjutsu-build/issues"
   },
   "peerDependencies": {
-    "@ninjutsu-build/core": "^0.8.8",
+    "@ninjutsu-build/core": "^0.8.9",
     "esbuild": "^0.20.2",
     "node-jq": "^4.3.1"
   }

--- a/packages/esbuild/src/esbuild.ts
+++ b/packages/esbuild/src/esbuild.ts
@@ -93,7 +93,7 @@ export function makeESBuildRule(
   out: O;
   buildOptions?: Omit<BuildOptions, "outfile">;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: string) => string | readonly string[];
 }) => O {
@@ -134,7 +134,7 @@ export function makeESBuildRule(
     out: O;
     buildOptions?: Omit<BuildOptions, "outfile">;
     [implicitDeps]?: string | readonly string[];
-    [orderOnlyDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
     [implicitOut]?: string | readonly string[];
     [validations]?: (out: string) => string | readonly string[];
   }): O => {

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/node",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "engines": {
         "node": ">=18.18.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.0"
+        "@ninjutsu-build/core": "^0.8.9"
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.0.tgz",
-      "integrity": "sha512-ghFc9xYY6czyriOYU0dd0IAGihIPniI7AZOytlilarOZ+REH6d6/P5kCticGHq8D/muG1mZ7w+kKV4ItCeh9Mg==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.9.tgz",
+      "integrity": "sha512-+PhAtaz0kMl/oMf+JN9NDZtpgN208WRwt5gTJsAN4fcwVRAlsaPxun3PBVIT7hJXZ2PW2IQ4VYretvNWta6pFA==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {
@@ -29,6 +29,6 @@
     "url": "https://github.com/elliotgoodrich/ninjutsu-build/issues"
   },
   "peerDependencies": {
-    "@ninjutsu-build/core": "^0.8.0"
+    "@ninjutsu-build/core": "^0.8.9"
   }
 }

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -82,7 +82,7 @@ export function makeNodeRule(
   args?: string;
   nodeArgs?: string;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: string) => string | readonly string[];
 }) => O {
@@ -137,7 +137,7 @@ export function makeNodeTestRule(
   args?: string;
   nodeArgs?: string;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: string) => string | readonly string[];
 }) => O {

--- a/packages/tsc/package-lock.json
+++ b/packages/tsc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/tsc",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.2.2"
@@ -15,13 +15,13 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.8"
+        "@ninjutsu-build/core": "^0.8.9"
       }
     },
     "node_modules/@ninjutsu-build/core": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.8.tgz",
-      "integrity": "sha512-3bp/9Zi7Uxb8Du/LfbJhzEYypT2zMW87gflPLpcS5AQe6Ha8KXi20kNokzwFwprexKPXKc55Z9edkKaLMImcJw==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/core/-/core-0.8.9.tgz",
+      "integrity": "sha512-+PhAtaz0kMl/oMf+JN9NDZtpgN208WRwt5gTJsAN4fcwVRAlsaPxun3PBVIT7hJXZ2PW2IQ4VYretvNWta6pFA==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {
@@ -33,6 +33,6 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@ninjutsu-build/core": "^0.8.8"
+    "@ninjutsu-build/core": "^0.8.9"
   }
 }

--- a/packages/tsc/src/tsc.ts
+++ b/packages/tsc/src/tsc.ts
@@ -128,7 +128,7 @@ export function makeTypeCheckRule(
   out: O;
   compilerOptions?: CompilerOptions;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: string) => string | readonly string[];
 }) => { file: string; [validations]: O }[] {
@@ -150,7 +150,7 @@ export function makeTypeCheckRule(
     out: O;
     compilerOptions?: CompilerOptions;
     [implicitDeps]?: string | readonly string[];
-    [orderOnlyDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
     [implicitOut]?: string | readonly string[];
     [validations]?: (out: string) => string | readonly string[];
   }): { file: string; [validations]: O }[] => {
@@ -236,7 +236,7 @@ export function makeTSCRule(
   in: readonly Input<string>[];
   compilerOptions?: CompilerOptions;
   [implicitDeps]?: string | readonly string[];
-  [orderOnlyDeps]?: string | readonly string[];
+  [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
   [implicitOut]?: string | readonly string[];
   [validations]?: (out: readonly string[]) => string | readonly string[];
 }) => readonly string[] {
@@ -257,7 +257,7 @@ export function makeTSCRule(
     in: readonly Input<string>[];
     compilerOptions?: CompilerOptions;
     [implicitDeps]?: string | readonly string[];
-    [orderOnlyDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
     [implicitOut]?: string | readonly string[];
     [validations]?: (out: readonly string[]) => string | readonly string[];
   }): readonly string[] => {


### PR DESCRIPTION
After the `@ninjutsu-build/core` accepted type for `orderOnlyDeps` has been widened, do the same for all plugins and bump up the dependencies.