### PR TITLE
Remove the option to compile with bun

### DIFF
--- a/configure/configure.mjs
+++ b/configure/configure.mjs
@@ -11,7 +11,6 @@ import {
   makeFormatRule,
   makeLintRule,
 } from "@ninjutsu-build/biome";
-import { makeTranspileRule } from "@ninjutsu-build/bun";
 import { basename, dirname, extname, join, relative } from "node:path/posix";
 import {
   resolve as resolveNative,
@@ -48,8 +47,6 @@ const extLookup = {
 };
 
 const prefix = platform() === "win32" ? "cmd /c " : "";
-
-const useBun = process.argv.includes("--bun");
 
 function makeNpmCiRule(ninja) {
   const ci = ninja.rule("npmci", {
@@ -239,12 +236,10 @@ const lint = addBiomeConfig(
     [orderOnlyDeps]: toolsInstalled,
   }),
 );
-const transpile = useBun
-  ? makeTranspileRule(ninja)
-  : inject(makeSWCRule(ninja), { [orderOnlyDeps]: toolsInstalled });
-const transpileArgs = useBun
-  ? "--target=node --no-bundle"
-  : "-C jsc.target=es2018";
+const transpile = inject(makeSWCRule(ninja), {
+  [orderOnlyDeps]: toolsInstalled,
+});
+const transpileArgs = "-C jsc.target=es2018";
 
 format({ in: "configure/configure.mjs" });
 

--- a/configure/package-lock.json
+++ b/configure/package-lock.json
@@ -8,7 +8,6 @@
       "devDependencies": {
         "@biomejs/biome": "1.4.0",
         "@ninjutsu-build/biome": "^0.8.3",
-        "@ninjutsu-build/bun": "^0.1.3",
         "@ninjutsu-build/core": "^0.8.9",
         "@ninjutsu-build/node": "^0.9.5",
         "@ninjutsu-build/tsc": "^0.12.2",
@@ -187,18 +186,6 @@
       },
       "peerDependencies": {
         "@biomejs/biome": "1.x",
-        "@ninjutsu-build/core": "^0.8.9"
-      }
-    },
-    "node_modules/@ninjutsu-build/bun": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/bun/-/bun-0.1.3.tgz",
-      "integrity": "sha512-UctBiPYNdb+XLF/8zkM/PYUOfa52SsJXeKQKLRMkvRpMoFeeyPrzuWucizU6f865uIkVZgmVdPJI50CU+D+55w==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
         "@ninjutsu-build/core": "^0.8.9"
       }
     },

--- a/configure/package.json
+++ b/configure/package.json
@@ -5,7 +5,6 @@
   "devDependencies": {
     "@biomejs/biome": "1.4.0",
     "@ninjutsu-build/biome": "^0.8.3",
-    "@ninjutsu-build/bun": "^0.1.3",
     "@ninjutsu-build/core": "^0.8.9",
     "@ninjutsu-build/node": "^0.9.5",
     "@ninjutsu-build/tsc": "^0.12.2",


### PR DESCRIPTION
Although bun's transpile is great and I am using it locally, we should stick with one canonical path through the configuration script to catch errors.