### PR TITLE
Remove the `lib` dir in the `node` plugin

### DIFF
--- a/packages/node/lib/file.d.cts
+++ b/packages/node/lib/file.d.cts
@@ -1,2 +1,0 @@
-export function open(outFile: string): void;
-export function logDependency(dependency: string): void;

--- a/packages/node/src/file.cts
+++ b/packages/node/src/file.cts
@@ -1,15 +1,15 @@
-const { openSync, writeFileSync } = require("node:fs");
-const { resolve, relative, isAbsolute } = require("node:path");
+import { openSync, writeFileSync } from "node:fs";
+import { resolve, relative, isAbsolute } from "node:path";
 
-let handle;
+let handle: number | undefined;
 const dir = resolve();
 
-function open(outFile) {
+export function open(outFile: string): void {
   handle = openSync(outFile + ".depfile", "w");
   writeFileSync(handle, outFile + ":");
 }
 
-function logDependency(dependency) {
+export function logDependency(dependency: string): void {
   if (handle === undefined) {
     // In this case we are most likely `require`ing ourselves before we've called
     // `open`. TODO: Fix the ordering in the future.
@@ -21,8 +21,3 @@ function logDependency(dependency) {
   ).replaceAll("\\", "/");
   writeFileSync(handle, " " + dep);
 }
-
-module.exports = {
-  open,
-  logDependency,
-};

--- a/packages/node/src/hookRequire.cts
+++ b/packages/node/src/hookRequire.cts
@@ -1,10 +1,10 @@
-const Module = require("module");
-const { dirname } = require("node:path");
-const { logDependency } = require("./file.cjs");
+const Module: NodeRequire = require("module");
+import { dirname } from "node:path";
+import { logDependency } from "./file.cjs";
 
-const r = Module.prototype.require;
+const r: RequireResolve = Module.prototype.require;
 
-Module.prototype.require = function (id) {
+Module.prototype.require = function (id: string): string {
   const paths = require.resolve.paths(id);
   // If `paths` is null then this is a core module (e.g. http or fs)
   if (paths !== null) {
@@ -12,6 +12,7 @@ Module.prototype.require = function (id) {
     try {
       Error.prepareStackTrace = (_, stack) => stack;
       const err = new Error();
+      //@ts-expect-error `err.stack` is lazily generated when accessed
       const paths = [dirname(err.stack[2].getFileName())];
       logDependency(require.resolve(id, { paths }));
     } finally {

--- a/packages/node/src/makeDepfile.ts
+++ b/packages/node/src/makeDepfile.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { isBuiltin } from "node:module";
-import { open, logDependency } from "../lib/file.cjs";
+import { open, logDependency } from "./file.cjs";
 
 export async function initialize(out: string): Promise<void> {
   open(out);

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -40,7 +40,7 @@ const node = platform() === "win32" ? "cmd /c node.exe" : "node";
 function getNodeCommand(ninja: NinjaBuilder): string {
   return `${node} --require "${resolvePath(
     ninja,
-    "../lib/hookRequire.cjs",
+    "./hookRequire.cjs",
   )}" --import "data:text/javascript,${getImportCode(ninja)}"`;
 }
 


### PR DESCRIPTION
Change the command arguments to SWC based on the TypeScript file extension so that we can target both CommonJS and ESModules.

After this we can move all of the JavaScript in the `node/lib` directory into `node/src` and convert them to TypeScript.