### PR TITLE
Remove bun references

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ writeFileSync("build.ninja", ninja.output);
   1. Install `node` (>18)
   2. Install `ninja` (>1.11)
   3. `npm ci --prefix configure`
-  4. `npm run configure` (`npm run configure -- --bun` to use `bun` instead of `swc` for transpiling)
+  4. `npm run configure`
 
 ### Building + linting + formatting + tests
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,1 +1,0 @@
-logLevel = "error" # Currently this isn't working in bun


### PR DESCRIPTION
Remove `bunfig.toml` and references to building with bun from `README.md` after we removed that option previously.