### PR TITLE
Don't special case integration package

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,3 @@
+# Integration
+
+A package for integration builds for `ninjutsu-build` and its plugins.

--- a/integration/src/util.d.mts
+++ b/integration/src/util.d.mts
@@ -1,1 +1,0 @@
-export declare function getDeps(cwd: string): Record<string, string[]>;

--- a/integration/src/util.mts
+++ b/integration/src/util.mts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 
-export function getDeps(cwd) {
-  const deps = {};
+export function getDeps(cwd: string): Record<string, string[]> {
+  const deps: Record<string, string[]> = {};
   let name = "";
   for (const line of execSync("ninja -t deps", { cwd })
     .toString()


### PR DESCRIPTION
Simplify the configuration script and don't special case the integration package.  The only downside from this change is that we unnecessarily create an `integration.tgz` archive.  This is comparatively quick and shouldn't be a performance concern.