### PR TITLE
Test module customization hooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,4 +28,5 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - run: cd configure && npm ci
     - run: npm run configure
+    - run: node --import ./hookImport.mjs ./index.mjs
     - run: ninja -k 0

--- a/a.mjs
+++ b/a.mjs
@@ -1,0 +1,1 @@
+export const hello = "hello";

--- a/hookImport.mjs
+++ b/hookImport.mjs
@@ -1,0 +1,15 @@
+import { register } from 'node:module';
+import { MessageChannel } from 'node:worker_threads';
+
+// This example showcases how a message channel can be used to communicate
+// between the main (application) thread and the hooks running on the hooks
+// thread, by sending `port2` to the `initialize` hook.
+const { port1, port2 } = new MessageChannel();
+
+port1.on('message', (msg) => { console.log(msg); });
+
+register('./path-to-my-hooks.mjs', {
+  parentURL: import.meta.url,
+  data: { port: port2 },
+  transferList: [port2],
+});

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,3 @@
+import { hello } from "./a.mjs";
+
+console.log(hello);

--- a/path-to-my-hooks.mjs
+++ b/path-to-my-hooks.mjs
@@ -1,0 +1,3 @@
+export async function initialize({ port }) {
+  port.postMessage(" world");
+}


### PR DESCRIPTION
When testing locally this hangs unless we manually `close()` `port2`.