### PR TITLE
Add back in windows-latest/node-latest CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node: [lts/-1, lts/*, latest]
-        exclude:
-          - os: windows-latest # There is currently an external issue with this combo
-            node: latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This was disabled in 4303d11688017a457a10489aa2743b509b5d9ef3 due to failures calling `npm ci --prefix configure` but the issue seems to have resolved itself - perhaps an issue with the GitHub runners.