### PR TITLE
Add `node_hooks` experiment

### DIFF
--- a/experiments/node_hooks/README.md
+++ b/experiments/node_hooks/README.md
@@ -1,0 +1,4 @@
+This tests out using import and require hooks to see under which circumstances each are used and on what threads:
+
+`node --import ./hookImport.mjs --require ./hookRequire.mjs ./index.mjs`
+`node --import ./hookImport.mjs --require ./hookRequire.mjs ./index.cjs`

--- a/experiments/node_hooks/hookImport.mjs
+++ b/experiments/node_hooks/hookImport.mjs
@@ -1,0 +1,6 @@
+import { threadId } from 'node:worker_threads';
+import { register } from 'node:module';
+
+console.log(`${threadId}: hookImport.mjs`);
+
+register('./load.mjs', import.meta.url);

--- a/experiments/node_hooks/hookRequire.cjs
+++ b/experiments/node_hooks/hookRequire.cjs
@@ -1,0 +1,9 @@
+const { threadId } = require('node:worker_threads');
+const Module = require("module");
+console.log(`${threadId}: hookRequire.cjs`);
+const r = Module.prototype.require;
+Module.prototype.require = function(id) {
+    //console.log(this);
+    console.log(`${threadId}: require(${id})`);
+    return r.call(this, id);
+};

--- a/experiments/node_hooks/index.cjs
+++ b/experiments/node_hooks/index.cjs
@@ -1,0 +1,3 @@
+const a_cjs = require("./nested/a.cjs");
+
+console.log("CommonJS entry point");

--- a/experiments/node_hooks/index.mjs
+++ b/experiments/node_hooks/index.mjs
@@ -1,0 +1,4 @@
+import a_mjs from "./nested/a.mjs"
+import a_cjs from "./nested/a.cjs"
+
+console.log("ESM entry point");

--- a/experiments/node_hooks/load.mjs
+++ b/experiments/node_hooks/load.mjs
@@ -1,0 +1,15 @@
+import { threadId } from 'node:worker_threads';
+console.log(`${threadId}: load.mjs`);
+
+export async function initialize() {
+  console.log(`${threadId}: initialize()`);
+}
+
+export async function load(
+  url,
+  context,
+  nextLoad,
+) {
+  console.log(`${threadId}: load(${url})`);
+  return nextLoad(url, context);
+}

--- a/experiments/node_hooks/nested/a.cjs
+++ b/experiments/node_hooks/nested/a.cjs
@@ -1,0 +1,3 @@
+const aa_cjs = require("./nested/aa.cjs");
+
+exports.default = "a.cjs";

--- a/experiments/node_hooks/nested/a.mjs
+++ b/experiments/node_hooks/nested/a.mjs
@@ -1,0 +1,7 @@
+import aa_mjs from "./nested/aa.mjs";
+import aa_cjs from "./nested/aa.cjs";
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+require("./nested/bb.cjs");
+
+export default "a.cjs";

--- a/experiments/node_hooks/nested/b.cjs
+++ b/experiments/node_hooks/nested/b.cjs
@@ -1,0 +1,3 @@
+const bb_cjs = require("./nested/bb.cjs");
+
+exports.default = "b.cjs";

--- a/experiments/node_hooks/nested/b.mjs
+++ b/experiments/node_hooks/nested/b.mjs
@@ -1,0 +1,4 @@
+import bb_mjs from "./nested/bb.mjs";
+import bb_cjs from "./nested/bb.cjs";
+
+exports.default = "b.cjs";

--- a/experiments/node_hooks/nested/nested/aa.cjs
+++ b/experiments/node_hooks/nested/nested/aa.cjs
@@ -1,0 +1,1 @@
+exports.default = "aa.cjs";

--- a/experiments/node_hooks/nested/nested/aa.mjs
+++ b/experiments/node_hooks/nested/nested/aa.mjs
@@ -1,0 +1,1 @@
+export default "aa.mjs";

--- a/experiments/node_hooks/nested/nested/bb.cjs
+++ b/experiments/node_hooks/nested/nested/bb.cjs
@@ -1,0 +1,1 @@
+exports.default = "bb.cjs";


### PR DESCRIPTION
There are currently issues with generating the node depfile:
  * CommonJS doesn't work because the `--import` code runs on a separate thread
  * I'm not sure if `createRequire` works in ESM

These need to be addressed and it's easier with a playground to experiment.