### PR TITLE
Add `@ninjutsu-build/node/runtime`

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -20,11 +20,11 @@
     "url": "https://github.com/elliotgoodrich/ninjutsu-build/issues"
   },
   "devDependencies": {
-    "@ninjutsu-build/core": "^0.8.5",
-    "@ninjutsu-build/biome": "^0.8.2",
-    "@ninjutsu-build/esbuild": "^0.1.0",
-    "@ninjutsu-build/node": "^0.9.1",
-    "@ninjutsu-build/tsc": "^0.12.1",
+    "@ninjutsu-build/core": "*",
+    "@ninjutsu-build/biome": "*",
+    "@ninjutsu-build/esbuild": "*",
+    "@ninjutsu-build/node": "*",
+    "@ninjutsu-build/tsc": "*",
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"
   }

--- a/integration/src/util.mts
+++ b/integration/src/util.mts
@@ -1,4 +1,5 @@
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
+import { strict as assert } from "node:assert";
 
 export function getDeps(cwd: string): Record<string, string[]> {
   const deps: Record<string, string[]> = {};
@@ -20,4 +21,49 @@ export function getDeps(cwd: string): Record<string, string[]> {
   }
 
   return deps;
+}
+
+export function callNinja(cwd: string): string {
+  const { stdout, stderr, status } = spawnSync("ninja", ["-d", "keepdepfile"], {
+    cwd,
+  });
+  const stdoutStr = stdout.toString();
+  assert.strictEqual(stderr.toString(), "");
+  assert.strictEqual(status, 0, stdoutStr);
+  return stdoutStr;
+}
+
+export function depsMatch(
+  actual: Record<string, string[]>,
+  expected: Record<string, (string | RegExp)[]>,
+): void {
+  assert.deepEqual(Object.keys(actual).sort(), Object.keys(expected).sort());
+
+  for (const key in expected) {
+    const expectedArr = expected[key];
+    const actualArr = actual[key];
+    assert.strictEqual(
+      expectedArr.length,
+      actualArr.length,
+      `Array mismatch with ${key}, expected ${actualArr.length} items but got ${expectedArr.length}`,
+    );
+    const found = new Set<number>();
+    for (let i = 0; i < expectedArr.length; ++i) {
+      const value = expectedArr[i];
+      const index =
+        typeof value === "string"
+          ? actualArr.indexOf(value)
+          : actualArr.findIndex((s) => value.test(s));
+      assert.notEqual(
+        index,
+        -1,
+        `Could not find ${value} in dependencies for ${key}`,
+      );
+      assert(
+        !found.has(index),
+        `Duplicate value match ${value} in dependencies for ${key}`,
+      );
+      found.add(index);
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@ninjutsu-build/biome": "^0.8.2",
         "@ninjutsu-build/core": "^0.8.5",
         "@ninjutsu-build/esbuild": "^0.1.0",
-        "@ninjutsu-build/node": "^0.9.1",
+        "@ninjutsu-build/node": "^0.10.0",
         "@ninjutsu-build/tsc": "^0.12.1",
         "@types/node": "^20.9.0",
         "typescript": "^5.2.2"
@@ -2000,30 +2000,30 @@
     },
     "packages/biome": {
       "name": "@ninjutsu-build/biome",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@biomejs/biome": "1.x",
-        "@ninjutsu-build/core": "^0.8.7"
+        "@ninjutsu-build/core": "^0.8.9"
       }
     },
     "packages/bun": {
       "name": "@ninjutsu-build/bun",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.2"
+        "@ninjutsu-build/core": "^0.8.9"
       }
     },
     "packages/core": {
       "name": "@ninjutsu-build/core",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "MIT",
       "devDependencies": {
         "tsafe": "^1.6.6"
@@ -2034,31 +2034,31 @@
     },
     "packages/esbuild": {
       "name": "@ninjutsu-build/esbuild",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.8",
+        "@ninjutsu-build/core": "^0.8.9",
         "esbuild": "^0.20.2",
         "node-jq": "^4.3.1"
       }
     },
     "packages/node": {
       "name": "@ninjutsu-build/node",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.18.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.0"
+        "@ninjutsu-build/core": "^0.8.9"
       }
     },
     "packages/tsc": {
       "name": "@ninjutsu-build/tsc",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.2.2"
@@ -2067,7 +2067,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@ninjutsu-build/core": "^0.8.8"
+        "@ninjutsu-build/core": "^0.8.9"
       }
     }
   }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {
@@ -10,6 +10,10 @@
     "node": ">=18.18.0"
   },
   "main": "dist/node.js",
+  "exports": {
+    ".": "./dist/node.js",
+    "./runtime": "./dist/runtime.cjs"
+  },
   "keywords": [
     "ninjutsu",
     "ninjutsu-build",

--- a/packages/node/src/depfile.cts
+++ b/packages/node/src/depfile.cts
@@ -4,12 +4,67 @@ import { resolve, relative, isAbsolute } from "node:path";
 let fd: number;
 let cwd: string;
 
+/**
+ * Open the corresponding depfile for the specified `out` file.  Note that this
+ * must be called before any calls to `addDependency`.
+ * @private
+ */
 export function open(out: string): void {
   cwd = resolve();
   fd = openSync(out + ".depfile", "w");
   writeFileSync(fd, out + ":");
 }
 
+/**
+ * Add to ninja's dynamic dependencies the specified `path` for the currently
+ * running script.
+ *
+ * For example, if we want to execute a "script.mjs" file with
+ * ninja we can write:
+ *
+ * ```ts
+ * import { NinjaBuilder } from "@ninjutsu-build/core";
+ * import { makeNodeRule } from "@ninjutsu-build/node";
+ *
+ * const ninja = new NinjaBuilder();
+ * const node = makeNodeRule(ninja);
+ * node({
+ *   in: "script.mjs",
+ *   out: "$builddir/out.txt",
+ * });
+ * ```
+ *
+ * If "script.mjs" imports or requires another file then the `node` rule will
+ * automatically add that JavaScript file to the dependencies of "script.mjs".
+ *
+ * However, if "script.mjs" decides to read a file without importing:
+ *
+ * ```ts
+ * // script.mjs
+ * import { readFileSync } from "node:fs";
+ *
+ * const myJson = "config.json";
+ * const config = JSON.parse(readFileSync(myJson));
+ *
+ * // ...
+ * ```
+ *
+ * then ninja will not know about the dependency on "config.json" and will not
+ * rerun this build edge when if is modified.  This can be fixed using the
+ * `addDependency` method to notify ninja,
+ *
+ * ```ts
+ * // script.mjs
+ * import { addDependency } from "@ninjutsu-build/node/runtime";
+ * import { readFileSync } from "node:fs";
+ *
+ * const myJson = "config.json";
+ * addDependency(myJson);
+ * const config = JSON.parse(readFileSync(myJson));
+ *
+ * // ...
+ * ```
+ */
 export function addDependency(path: string): void {
   const relPath = relative(cwd, path);
   const dependency = (

--- a/packages/node/src/runtime.cts
+++ b/packages/node/src/runtime.cts
@@ -1,0 +1,1 @@
+export { addDependency } from "./depfile.cjs";


### PR DESCRIPTION
Add an entry point that can be used by JavaScript executed by `makeNodeRule` to report additional dependencies such as files read with `node:fs`.

This can be used by scripts who read additional files that are not either `import`ed or `require`d.