### PR TITLE
Fix created `.tgz` files

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@ninjutsu-build/integration",
-  "version": "0.0.1",
   "description": "Integration tests for the plugins",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
After swapping to workspaces the contents of the `.tgz` files were changed so that they are no longer valid npm packages.  `.tgz` files need to have 1 folder within them (of any name) and then the `package.json` file within that folder.

We were accidentally putting `package.json` within an extra level of directory nesting.

This change fixes it by updating the `dir` property passed to the `tar` function.  Additionally we stop creating `.tgz` files for the integration package as this is not needed at the moment.