### PR TITLE
Allow non-console output in node

### DIFF
--- a/integration/src/esbuild.test.mts
+++ b/integration/src/esbuild.test.mts
@@ -55,6 +55,7 @@ describe("esbuild tests", () => {
     const output = node({
       in: entry,
       out: "output.txt",
+      args: ">",
     });
     writeFileSync(join(dir, "build.ninja"), ninja.output);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,13 @@
     },
     "integration": {
       "name": "@ninjutsu-build/integration",
-      "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@ninjutsu-build/biome": "^0.8.2",
-        "@ninjutsu-build/core": "^0.8.5",
-        "@ninjutsu-build/esbuild": "^0.1.0",
-        "@ninjutsu-build/node": "^0.10.0",
-        "@ninjutsu-build/tsc": "^0.12.1",
+        "@ninjutsu-build/biome": "*",
+        "@ninjutsu-build/core": "*",
+        "@ninjutsu-build/esbuild": "*",
+        "@ninjutsu-build/node": "*",
+        "@ninjutsu-build/tsc": "*",
         "@types/node": "^20.9.0",
         "typescript": "^5.2.2"
       },
@@ -2047,7 +2046,7 @@
     },
     "packages/node": {
       "name": "@ninjutsu-build/node",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.18.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/node/src/node.test.mts
+++ b/packages/node/src/node.test.mts
@@ -6,7 +6,7 @@ import { makeNodeRule, makeNodeTestRule } from "./node.js";
 test("makeNodeRule", () => {
   const ninja = new NinjaBuilder();
   const node = makeNodeRule(ninja);
-  const out: "out.txt" = node({ out: "out.txt", in: "in.js" });
+  const out: "out.txt" = node({ out: "out.txt", in: "in.js", args: "" });
   assert.equal(out, "out.txt");
   const myNode = makeNodeRule(ninja, "myNode");
   const out2: "out2.txt" = myNode({


### PR DESCRIPTION
Having the JavaScript file write to stdout is convenience but is problematic in the case of errors.  In this case we probably would want to print stderr to the console and not stdout.  This requires a bit more complexity on our part and perhaps an additional script/executable to take the output of node and print stderr on error.

There are many scripts that take a specified output file to write to via command line arguments and we should support these as well.

This commit gives a bit more flexibility to the output format for running node. I am not 100% behind the current syntax but it can be improved later on when I get inpsiration.