### PR TITLE
Use `isolatedModules: true` in build

### DIFF
--- a/configure/configure.mjs
+++ b/configure/configure.mjs
@@ -196,6 +196,7 @@ const compilerOptions = {
   noFallthroughCasesInSwitch: true,
   skipDefaultLibCheck: true,
   skipLibCheck: true,
+  isolatedModules: true,
 };
 
 const ninja = new NinjaBuilder({


### PR DESCRIPTION
We are using `swc` to transpile TypeScript into JavaScript so we cannot be using things like TypeScript's enums since `swc` only looks at the source TypeScript file when transpiling (by design).

Since we don't (and are not planning to) use any of these TypeScript features, we can add `isolatedModules: true` to catch any uses of these features and avoid any transpilation issues.