### PR TITLE
Allow `compilerOptions` with a tsconfig file

### DIFF
--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
Allow passing an optional `compilerOptions` property when using a tsconfig file in `@ninjutsu-build/tsc` rules.  This will allow users to have a standard tsconfig file, but selectively supply (or override) options such as `outDir` or `declaration` that may differ per-project.