### PR TITLE
Allow `extends` property in `tsconfig.json` files

### DIFF
--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
`tsc` supports `tsconfig.json` files having an `extends` property, which references another JSON file that can contain additional properties that will be used.

Update `parseOutput.mts` to output the list of config files as part of the `dyndep` file so we will re-typecheck/transpile whenever the config file is updated.  Note that is is not perfect - it will break if you change any option that controls the number or paths of the output files, or you add/remove additional files in `extends`.  However, if you are changing warning levels or anything to do with typechecking it should work well.

Additionally, use the parser inside `typescript` instead of `JSON.parse` as the format is `jsonc` (JSON with comments) and not pure JSON.