### PR TITLE
Fix issues in `tsconfig.json` in subdirectory

### DIFF
--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
When testing out the latest `tsc` changes there were several issues that cropped up when `ninja` is run from a parent directory to the `tsconfig.json` - mostly around output files not having the additional directory prefix. These issues were:

  * `getInput` not called on `tsconfig` so inputs containing additional validations or order-only dependencies would fail to serialize correctly
  * the directory that `tsconfig.json` is in was not prepended to the final paths returned by the function
  * all of the compile options from the `tsconfig.json` were being added as command line arguments instead of only the overrides