### PR TITLE
Add missing properties in `tsc`

### DIFF
--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/tsc/src/tsc.ts
+++ b/packages/tsc/src/tsc.ts
@@ -354,11 +354,12 @@ export function makeTypeCheckRule(
         [validations]: typechecked,
       }));
     } else {
+      const { tsConfig, compilerOptions = {}, ...rest } = a;
       const typechecked = typecheck({
-        in: [a.tsConfig],
-        out: a.out,
-        args: compilerOptionsToString(a.compilerOptions ?? {}) + " -p",
-        tsconfig: `--tsconfig ${getInput(a.tsConfig)}`,
+        in: [tsConfig],
+        args: compilerOptionsToString(compilerOptions) + " -p",
+        tsconfig: `--tsconfig ${getInput(tsConfig)}`,
+        ...rest,
       });
       const directory = dirname(getInput(a.tsConfig));
       return getFileNames(ninja, a.tsConfig).then((files) =>


### PR DESCRIPTION
We forget to pass the rest of the options through in `@ninjutsu-build/tsc` when using a `tsconfig.json` file so it doesn't pick up on things like additional order-only dependencies.