### PR TITLE
Convert to using `tsconfig.json`

### DIFF
--- a/configure/package-lock.json
+++ b/configure/package-lock.json
@@ -10,7 +10,7 @@
         "@ninjutsu-build/biome": "^0.8.3",
         "@ninjutsu-build/core": "^0.8.9",
         "@ninjutsu-build/node": "^0.9.5",
-        "@ninjutsu-build/tsc": "^0.12.2",
+        "@ninjutsu-build/tsc": "^0.12.7",
         "@swc/cli": "^0.3.12",
         "@swc/core": "^1.4.17",
         "@types/node": "^20.12.7",
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@ninjutsu-build/tsc": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/@ninjutsu-build/tsc/-/tsc-0.12.3.tgz",
-      "integrity": "sha512-PX6LP8bwvyI7K8TrCq0rAhpsmlebIsEvruFHycrazZZvZjaweKYepeXswUYnIaFJH/8b7okG71AJ+EFBYzzAdg==",
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@ninjutsu-build/tsc/-/tsc-0.12.8.tgz",
+      "integrity": "sha512-6WbLRY1N99/byoHvD+ylBnTFsCWrxyNrgCHA8mH3+NyBnW5TtSpHPnF4VVP+Zp0nE3N5f66qHZ5KYXA8D/PzLQ==",
       "dev": true,
       "dependencies": {
         "typescript": "^5.2.2"
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@swc/cli": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.3.12.tgz",
-      "integrity": "sha512-h7bvxT+4+UDrLWJLFHt6V+vNAcUNii2G4aGSSotKz1ECEk4MyEh5CWxmeSscwuz5K3i+4DWTgm4+4EyMCQKn+g==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.3.14.tgz",
+      "integrity": "sha512-0vGqD6FSW67PaZUZABkA+ADKsX7OUY/PwNEz1SbQdCvVk/e4Z36Gwh7mFVBQH9RIsMonTyhV1RHkwkGnEfR3zQ==",
       "dev": true,
       "dependencies": {
         "@mole-inc/bin-wrapper": "^8.0.1",
@@ -317,14 +317,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.24.tgz",
-      "integrity": "sha512-Eph9zvO4xvqWZGVzTdtdEJ0Vqf0VIML/o/e4Qd2RLOqtfgnlRi7avmMu5C0oqciJ0tk+hqdUKVUZ4JPoPaiGvQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.6.tgz",
+      "integrity": "sha512-sHfmIUPUXNrQTwFMVCY5V5Ena2GTOeaWjS2GFUpjLhAgVfP90OP67DWow7+cYrfFtqBdILHuWnjkTcd0+uPKlg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.7"
+        "@swc/types": "^0.1.9"
       },
       "engines": {
         "node": ">=10"
@@ -334,16 +334,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.5.24",
-        "@swc/core-darwin-x64": "1.5.24",
-        "@swc/core-linux-arm-gnueabihf": "1.5.24",
-        "@swc/core-linux-arm64-gnu": "1.5.24",
-        "@swc/core-linux-arm64-musl": "1.5.24",
-        "@swc/core-linux-x64-gnu": "1.5.24",
-        "@swc/core-linux-x64-musl": "1.5.24",
-        "@swc/core-win32-arm64-msvc": "1.5.24",
-        "@swc/core-win32-ia32-msvc": "1.5.24",
-        "@swc/core-win32-x64-msvc": "1.5.24"
+        "@swc/core-darwin-arm64": "1.6.6",
+        "@swc/core-darwin-x64": "1.6.6",
+        "@swc/core-linux-arm-gnueabihf": "1.6.6",
+        "@swc/core-linux-arm64-gnu": "1.6.6",
+        "@swc/core-linux-arm64-musl": "1.6.6",
+        "@swc/core-linux-x64-gnu": "1.6.6",
+        "@swc/core-linux-x64-musl": "1.6.6",
+        "@swc/core-win32-arm64-msvc": "1.6.6",
+        "@swc/core-win32-ia32-msvc": "1.6.6",
+        "@swc/core-win32-x64-msvc": "1.6.6"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.24.tgz",
-      "integrity": "sha512-M7oLOcC0sw+UTyAuL/9uyB9GeO4ZpaBbH76JSH6g1m0/yg7LYJZGRmplhDmwVSDAR5Fq4Sjoi1CksmmGkgihGA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.6.tgz",
+      "integrity": "sha512-5DA8NUGECcbcK1YLKJwNDKqdtTYDVnkfDU1WvQSXq/rU+bjYCLtn5gCe8/yzL7ISXA6rwqPU1RDejhbNt4ARLQ==",
       "cpu": [
         "arm64"
       ],
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.24.tgz",
-      "integrity": "sha512-MfcFjGGYognpSBSos2pYUNYJSmqEhuw5ceGr6qAdME7ddbjGXliza4W6FggsM+JnWwpqa31+e7/R+GetW4WkaQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.6.tgz",
+      "integrity": "sha512-2nbh/RHpweNRsJiYDFk1KcX7UtaKgzzTNUjwtvK5cp0wWrpbXmPvdlWOx3yzwoiSASDFx78242JHHXCIOlEdsw==",
       "cpu": [
         "x64"
       ],
@@ -387,9 +387,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.24.tgz",
-      "integrity": "sha512-amI2pwtcWV3E/m/nf+AQtn1LWDzKLZyjCmWd3ms7QjEueWYrY8cU1Y4Wp7wNNsxIoPOi8zek1Uj2wwFD/pttNQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.6.tgz",
+      "integrity": "sha512-YgytuyUfR7b0z0SRHKV+ylr83HmgnROgeT7xryEkth6JGpAEHooCspQ4RrWTU8+WKJ7aXiZlGXPgybQ4TiS+TA==",
       "cpu": [
         "arm"
       ],
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.24.tgz",
-      "integrity": "sha512-sTSvmqMmgT1ynH/nP75Pc51s+iT4crZagHBiDOf5cq+kudUYjda9lWMs7xkXB/TUKFHPCRK0HGunl8bkwiIbuw==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.6.tgz",
+      "integrity": "sha512-yGwx9fddzEE0iURqRVwKBQ4IwRHE6hNhl15WliHpi/PcYhzmYkUIpcbRXjr0dssubXAVPVnx6+jZVDSbutvnfg==",
       "cpu": [
         "arm64"
       ],
@@ -419,9 +419,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.24.tgz",
-      "integrity": "sha512-vd2/hfOBGbrX21FxsFdXCUaffjkHvlZkeE2UMRajdXifwv79jqOHIJg3jXG1F3ZrhCghCzirFts4tAZgcG8XWg==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.6.tgz",
+      "integrity": "sha512-a6fMbqzSAsS5KCxFJyg1mD5kwN3ZFO8qQLyJ75R/htZP/eCt05jrhmOI7h2n+1HjiG332jLnZ9S8lkVE5O8Nqw==",
       "cpu": [
         "arm64"
       ],
@@ -435,9 +435,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.24.tgz",
-      "integrity": "sha512-Zrdzi7NqzQxm2BvAG5KyOSBEggQ7ayrxh599AqqevJmsUXJ8o2nMiWQOBvgCGp7ye+Biz3pvZn1EnRzAp+TpUg==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.6.tgz",
+      "integrity": "sha512-hRGsUKNzzZle28YF0dYIpN0bt9PceR9LaVBq7x8+l9TAaDLFbgksSxcnU/ubTtsy+WsYSYGn+A83w3xWC0O8CQ==",
       "cpu": [
         "x64"
       ],
@@ -451,9 +451,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.24.tgz",
-      "integrity": "sha512-1F8z9NRi52jdZQCGc5sflwYSctL6omxiVmIFVp8TC9nngjQKc00TtX/JC2Eo2HwvgupkFVl5YQJidAck9YtmJw==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.6.tgz",
+      "integrity": "sha512-NokIUtFxJDVv3LzGeEtYMTV3j2dnGKLac59luTeq36DQLZdJQawQIdTbzzWl2jE7lxxTZme+dhsVOH9LxE3ceg==",
       "cpu": [
         "x64"
       ],
@@ -467,9 +467,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.24.tgz",
-      "integrity": "sha512-cKpP7KvS6Xr0jFSTBXY53HZX/YfomK5EMQYpCVDOvfsZeYHN20sQSKXfpVLvA/q2igVt1zzy1XJcOhpJcgiKLg==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.6.tgz",
+      "integrity": "sha512-lzYdI4qb4k1dFG26yv+9Jaq/bUMAhgs/2JsrLncGjLof86+uj74wKYCQnbzKAsq2hDtS5DqnHnl+//J+miZfGA==",
       "cpu": [
         "arm64"
       ],
@@ -483,9 +483,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.24.tgz",
-      "integrity": "sha512-IoPWfi0iwqjZuf7gE223+B97/ZwkKbu7qL5KzGP7g3hJrGSKAvv7eC5Y9r2iKKtLKyv5R/T6Ho0kFR/usi7rHw==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.6.tgz",
+      "integrity": "sha512-bvl7FMaXIJQ76WZU0ER4+RyfKIMGb6S2MgRkBhJOOp0i7VFx4WLOnrmMzaeoPJaJSkityVKAftfNh7NBzTIydQ==",
       "cpu": [
         "ia32"
       ],
@@ -499,9 +499,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.24.tgz",
-      "integrity": "sha512-zHgF2k1uVJL8KIW+PnVz1To4a3Cz9THbh2z2lbehaF/gKHugH4c3djBozU4das1v35KOqf5jWIEviBLql2wDLQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.6.tgz",
+      "integrity": "sha512-WAP0JoCTfgeYKgOeYJoJV4ZS0sQUmU3OwvXa2dYYtMLF7zsNqOiW4niU7QlThBHgUv/qNZm2p6ITEgh3w1cltw==",
       "cpu": [
         "x64"
       ],
@@ -521,9 +521,9 @@
       "dev": true
     },
     "node_modules/@swc/types": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz",
-      "integrity": "sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.9.tgz",
+      "integrity": "sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==",
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.0.tgz",
-      "integrity": "sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==",
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -1271,15 +1271,16 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
         "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^1.11.1"
       },
       "bin": {
@@ -1459,9 +1460,9 @@
       "dev": true
     },
     "node_modules/jackspeak": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.2.0.tgz",
-      "integrity": "sha512-eXIwN9gutMuB1AMW241gIHSEeaSMafWnxWXb/JGYWqifway4QgqBJLl7nYlmhGrxnHQ3wNc/QYFZ95aDtHHzpA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -1566,9 +1567,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1701,6 +1702,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
+    },
     "node_modules/path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -1727,9 +1734,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
+      "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -1770,9 +1777,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.5.1.tgz",
-      "integrity": "sha512-DVhySLPfqAW+uRH9dF0bjA2xEWr5ANLAzkYXx5adSLMFnwssSIVJYhg0FlvgYsnT/khILQJ3WkjqbAlBvt+maw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.6.1.tgz",
+      "integrity": "sha512-z30AwWGtQE+Apr+2WBZensP2lIvwoaMcOPkQlIEmSGMJNUvaYACylPYrQM6wSdUNJlnDVMSpLv7xTMJqlVshOA==",
       "dev": true,
       "optionalDependencies": {
         "nice-napi": "^1.0.2"
@@ -2229,9 +2236,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/configure/package.json
+++ b/configure/package.json
@@ -7,7 +7,7 @@
     "@ninjutsu-build/biome": "^0.8.3",
     "@ninjutsu-build/core": "^0.8.9",
     "@ninjutsu-build/node": "^0.9.5",
-    "@ninjutsu-build/tsc": "^0.12.2",
+    "@ninjutsu-build/tsc": "^0.12.8",
     "@swc/cli": "^0.3.12",
     "@swc/core": "^1.4.17",
     "@types/node": "^20.12.7",

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig",
+  "files": ["src/util.mts"]
+}

--- a/integration/tsconfig.tests.json
+++ b/integration/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig",
+  "files": [
+    "src/biome.test.mts",
+    "src/esbuild.test.mts",
+    "src/node.test.mts",
+    "src/tsc.test.mts"
+  ]
+}

--- a/packages/biome/tsconfig.json
+++ b/packages/biome/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/biome.ts"]
+}

--- a/packages/biome/tsconfig.tests.json
+++ b/packages/biome/tsconfig.tests.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/biome.test.mts"]
+}

--- a/packages/bun/tsconfig.json
+++ b/packages/bun/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/bun.ts"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/core.ts"]
+}

--- a/packages/core/tsconfig.tests.json
+++ b/packages/core/tsconfig.tests.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/core.test.mts"]
+}

--- a/packages/esbuild/tsconfig.json
+++ b/packages/esbuild/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/esbuild.ts"]
+}

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig",
+  "files": [
+    "src/depfile.cts",
+    "src/hookImport.mts",
+    "src/hookRequire.cts",
+    "src/node.ts",
+    "src/runtime.cts",
+    "src/testReporter.mts"
+  ]
+}

--- a/packages/node/tsconfig.tests.json
+++ b/packages/node/tsconfig.tests.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/node.test.mts"]
+}

--- a/packages/tsc/tsconfig.json
+++ b/packages/tsc/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/tsc.ts", "src/parseOutput.mts"]
+}

--- a/packages/tsc/tsconfig.tests.json
+++ b/packages/tsc/tsconfig.tests.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "files": ["src/tsc.test.mts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "lib": ["ES2021"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
Swap over to `tsconfig.json` for a bunch of reasons:

  * VSCode shows erros when using `replaceAll` unless it finds a `tsconfig.json` with a recent enough library version
  * TypeDoc (and probably other tools) require a `tsconfig.json` file to work
  * Several things like the `paths` `tsc` option can only be supplied through `tsconfig.json` and using this is necessary for future changes where test files can import the library as `@ninjutsu-build/foo` rather than `./foo.js`