### PR TITLE
Fix doc generation build dependencies

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -6,22 +6,8 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: latest
-        cache: 'npm'
-    - run: cd configure && npm ci
-    - run: npm run docs
-    - uses: actions/upload-pages-artifact@v3
-      with:
-        path: "./docs"
   deploy:
     runs-on: ubuntu-latest
-    needs: build
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write
@@ -30,6 +16,20 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: latest
+        cache: 'npm'
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - run: cd configure && npm ci
+    - run: npm run configure
+    - run: ninja 
+    - run: ninja -k 0 prep-for-docs
+    - run: npm run docs
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: "./docs"
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/configure/configure.mjs
+++ b/configure/configure.mjs
@@ -247,6 +247,8 @@ format({ in: "configure/configure.mjs" });
 
 const baseConfig = format({ in: "tsconfig.json" });
 
+const docsDependencies = [];
+
 const scope = "@ninjutsu-build/";
 for (const cwd of workspaceJSON.workspaces) {
   const localPKGJSON = JSON.parse(
@@ -320,6 +322,8 @@ for (const cwd of workspaceJSON.workspaces) {
     in: [packageJSON, ...typeDeclarations].map(getOrderOnlyDeps),
   });
 
+  docsDependencies.push(packageHasTypes);
+
   // Type check all the tests
   const testTargets = await (async () => {
     if (!existsSync(join(cwd, "tsconfig.tests.json"))) {
@@ -392,5 +396,7 @@ for (const cwd of workspaceJSON.workspaces) {
     in: [packageHasTypes, packageRunnable, ...createTar, ...testTargets],
   });
 }
+
+phony({ out: "prep-for-docs", in: docsDependencies });
 
 writeFileSync("build.ninja", ninja.output);


### PR DESCRIPTION
To generate documentation we need to make sure that we have set up the `node_modules` for each of our packages so `typedoc` can run.