### PR TITLE
Handle `orderOnlyDeps` in `phony`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/core",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Easily create ninja build files with this TypeScript library (https://ninja-build.org/)",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/core/src/core.test.mts
+++ b/packages/core/src/core.test.mts
@@ -167,12 +167,19 @@ test("phony rule", () => {
   const out4: "none" = phony({ out: "none", in: [] });
   assert.equal(out4, "none");
 
+  const out5: "buildOrder" = phony({
+    out: "buildOrder",
+    in: ["in1", { file: "ignored", [orderOnlyDeps]: "in2" }],
+  });
+  assert.equal(out5, "buildOrder");
+
   assert.equal(
     ninja.output,
     `build alias: phony file.txt
 build my$:$:$ alia$$ !: phony file$$ .txt
 build all: phony in1 in2
 build none: phony
+build buildOrder: phony in1 in2
 `,
   );
 });

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -483,6 +483,11 @@ export class NinjaBuilder {
    * the `out` property of the first argument.  The `in` and `out` properties will be escaped
    * using {@link escapePath}.
    *
+   * If `in` has an `orderOnlyDep` property then that property value will be used instead of
+   * the `file` property.  Otherwise if `in` is an array, all elements inside that are objects
+   * containing `orderOnlyDeps` will have that property value taken instead of the `file`
+   * property.
+   *
    * See the ninja build manual on
    * {@link https://ninja-build.org/manual.html#_the_literal_phony_literal_rule | the phony rule}
    * for more information.
@@ -509,17 +514,17 @@ export class NinjaBuilder {
    */
   get phony(): <O extends string>(args: {
     out: O;
-    in: string | readonly string[];
+    in: Input<string> | readonly Input<string>[];
   }) => O {
     return <O extends string>(args: {
       out: O;
-      in: string | readonly string[];
+      in: Input<string> | readonly Input<string>[];
     }): O => {
       this.output +=
         "build " +
         escapePath(args.out) +
         ": phony" +
-        concatPaths(" ", args.in) +
+        concatPaths(" ", getOrderOnlyDeps(args.in)) +
         "\n";
       return args.out;
     };


### PR DESCRIPTION
When passing objects to `phony` that are the output of formatting rules, we actually want to make sure that the formatting has been applied when we run the phony rule.  This is similar to how we add `orderOnlyDeps` for other rules.