### PR TITLE
Change the signature of plugin `make*` functions

### DIFF
--- a/packages/biome/package.json
+++ b/packages/biome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/biome",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "A biome plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/biome/src/biome.test.mts
+++ b/packages/biome/src/biome.test.mts
@@ -15,7 +15,7 @@ import {
 
 test("makeLintRule", () => {
   const ninja = new NinjaBuilder();
-  const lint = makeLintRule(ninja);
+  const lint = makeLintRule(ninja, { name: "lint2" });
   const out: {
     file: "foo.js";
     [validations]: "$builddir/.ninjutsu-build/biome/lint/foo.js";
@@ -70,7 +70,10 @@ test("makeFormatRule", () => {
 
 test("makeFormatToRule", () => {
   const ninja = new NinjaBuilder();
-  const format = makeFormatToRule(ninja);
+  const format = makeFormatToRule(ninja, {
+    configPath: "biome.jsonc",
+    [implicitDeps]: "dummy",
+  });
   const out: "nice.js" = format({
     in: "ugly.js",
     out: "nice.js",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/bun",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A bun plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/esbuild",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "An esbuild plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/node/src/node.test.mts
+++ b/packages/node/src/node.test.mts
@@ -8,7 +8,7 @@ test("makeNodeRule", () => {
   const node = makeNodeRule(ninja);
   const out: "out.txt" = node({ out: "out.txt", in: "in.js", args: "" });
   assert.equal(out, "out.txt");
-  const myNode = makeNodeRule(ninja, "myNode");
+  const myNode = makeNodeRule(ninja, { name: "myNode" });
   const out2: "out2.txt" = myNode({
     out: "out2.txt",
     in: "in.js",
@@ -24,7 +24,7 @@ test("makeNodeTestRule", () => {
   const test = makeNodeTestRule(ninja);
   const out: "out.txt" = test({ out: "out.txt", in: "in.js" });
   assert.equal(out, "out.txt");
-  const myNode = makeNodeTestRule(ninja, "myTest");
+  const myNode = makeNodeTestRule(ninja, { name: "myTest" });
   const out2: "out2.txt" = myNode({
     out: "out2.txt",
     in: "in.js",

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.12.8",
+  "version": "0.13.0",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/tsc/src/tsc.test.mts
+++ b/packages/tsc/src/tsc.test.mts
@@ -66,6 +66,7 @@ test("Serializing CompilerOptions", () => {
 test("makeTSCRule", () => {
   const ninja = new NinjaBuilder();
   const tsc = makeTSCRule(ninja);
+  const tscNamed = makeTSCRule(ninja, { name: "typescript" });
   assert.deepEqual(
     tsc({
       in: ["src/common/index.ts"],
@@ -77,7 +78,7 @@ test("makeTSCRule", () => {
   );
 
   assert.deepEqual(
-    tsc({
+    tscNamed({
       in: ["index.cts"],
       compilerOptions: {
         declaration: true,

--- a/packages/tsc/src/tsc.ts
+++ b/packages/tsc/src/tsc.ts
@@ -253,6 +253,9 @@ export type TypeCheckRuleFn = {
  * No matter how files are specified, `tsc` compilation options can be supplied with
  * `compilerOptions` and will override any other options in the `tsconfig.json` file.
  *
+ * Any `implicitDeps` or `orderOnlyDeps` passed in `options` will be added to all build
+ * edges generated with the returned function.
+ *
  * WARNING! When adding new entry points to `tsconfig.json` or changing any options
  * that control the number or location of output files, the ninja file needs to be
  * regenerated to account for these.
@@ -306,8 +309,13 @@ export type TypeCheckRuleFn = {
  */
 export function makeTypeCheckRule(
   ninja: NinjaBuilder,
-  name = "typecheck",
+  options: {
+    name?: string;
+    [implicitDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
+  } = {},
 ): TypeCheckRuleFn {
+  const { name = "typecheck", ...rest } = options;
   const typecheck = ninja.rule(name, {
     command:
       prefix +
@@ -323,6 +331,7 @@ export function makeTypeCheckRule(
     deps: "gcc",
     args: needs<string>(),
     tsconfig: "",
+    ...rest,
   });
   return (<O extends string>(
     a: (
@@ -424,6 +433,9 @@ export type TSCRuleFn = {
  * No matter how files are specified, `tsc` compilation options can be supplied with
  * `compilerOptions` and will override any other options in the `tsconfig.json` file.
  *
+ * Any `implicitDeps` or `orderOnlyDeps` passed in `options` will be added to all build
+ * edges generated with the returned function.
+ *
  * WARNING! When adding new entry points to `tsconfig.json` or changing any options
  * that control the number or location of output files, the ninja file needs to be
  * regenerated to account for these.
@@ -478,7 +490,15 @@ export type TSCRuleFn = {
  * writeFileSync("build.ninja", ninja.output);
  * ```
  */
-export function makeTSCRule(ninja: NinjaBuilder, name = "tsc"): TSCRuleFn {
+export function makeTSCRule(
+  ninja: NinjaBuilder,
+  options: {
+    name?: string;
+    [implicitDeps]?: string | readonly string[];
+    [orderOnlyDeps]?: Input<string> | readonly Input<string>[];
+  } = {},
+): TSCRuleFn {
+  const { name = "tsc", ...rest } = options;
   const tsc = ninja.rule(name, {
     command:
       prefix +
@@ -494,6 +514,7 @@ export function makeTSCRule(ninja: NinjaBuilder, name = "tsc"): TSCRuleFn {
     out: needs<string>(),
     args: needs<string>(),
     tsconfig: "",
+    ...rest,
   });
   return ((
     a: (


### PR DESCRIPTION
A while ago `@ninjutsu-build/core` was updated so that `NinjaBuilder.rule` could take any properties and these were taken as the default value for any build edges created with this rule.

However, it was not possible to pass through arbitrary values for `implicitDeps` or `orderOnlyDeps` in the plugins, or to set defaults that we use ourselves (e.g. `configPath` for `@ninjutsu-build/biome`).

All plugin exports take an optional object as the second parameter instead of an optional string for the rule name.  This optional object can take the name, `implicitDeps`, `orderOnlyDeps`, and any rule-specific defaults that make sense.  Right now this is just `configPath` for `@ninjutsu-build/biome`, but later on we can add more.