### PR TITLE
Fix global variables in `@ninjutsu-build/node/runtime`

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
Replace global variabls with `global` instead as this was causing issues with variables being reinitialized with `undefined`.

Additionally, change `addDependency` to do nothing if `open` hasn't yet been called because it is easier to debug and there will be many situations where projects may want to try out `ninjutsu-build` in parallel to their existing system.  This allows them to add in `addDependency` where expected, but have this be a no-op in their existing build.