### PR TITLE
Add `@ninjutsu-build/tsc.getEntryPointsFromConfig`

### DIFF
--- a/integration/src/tsc.test.mts
+++ b/integration/src/tsc.test.mts
@@ -1,7 +1,11 @@
 import { beforeEach, test, describe } from "node:test";
 import { strict as assert } from "node:assert";
 import { NinjaBuilder, getInput, validations } from "@ninjutsu-build/core";
-import { makeTSCRule, makeTypeCheckRule } from "@ninjutsu-build/tsc";
+import {
+  getEntryPointsFromConfig,
+  makeTSCRule,
+  makeTypeCheckRule,
+} from "@ninjutsu-build/tsc";
 import { writeFileSync, mkdirSync, symlinkSync, existsSync } from "node:fs";
 import { join } from "node:path/posix";
 import {
@@ -269,6 +273,10 @@ describe("tsc", (suiteCtx) => {
       "src/myOutput/script.mjs",
       "src/myOutput/script.d.mts",
     ]);
+    assert.deepEqual(
+      await getEntryPointsFromConfig(ninja, "src/tsconfig.json"),
+      ["src/script.mts"],
+    );
 
     const typechecked = await typecheck({
       tsConfig: { file: "src/tsconfig.json" },

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/tsc",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Create a ninjutsu-build rule for running the TypeScript compiler (tsc)",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
Expose a function to return all TypeScript entry points as described by a `tsconfig.json` file.  For all projects using a `tsconfig.json` file, they will most likely have to use `getEntryPointsFromConfig` to get the entry points in the configuration script if these entry points need to be run later on and the users don't want to hardcode it.