### PR TITLE
Fix backslashes when calling `del`

### DIFF
--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/esbuild",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An esbuild plugin for ninjutsu-build",
   "author": "Elliot Goodrich",
   "scripts": {


### PR DESCRIPTION
`del` does not support forward slashes as directory separators and if we have any spaces in the path then it needs to be quoted.