### PR TITLE
Add trimja-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,9 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - run: cd configure && npm ci
     - run: npm run configure
+    - name: Run trimja
+      uses: elliotgoodrich/trimja-action@release
     - run: ninja -k 0
-    - run: npm run docs
 
   deploy:
     needs: build

--- a/guides/typedoc.jsonc
+++ b/guides/typedoc.jsonc
@@ -3,6 +3,7 @@
     "name": "Guides",
     "projectDocuments": [
         "Why Ninjutsu Build.md",
+        "Tutorial.md",
         "Ninjutsu Build Extras.md",
         "How to Write a Plugin.md",
     ],


### PR DESCRIPTION
Add trimja-action to install, setup, and use trimja to reduce the amount of work needed to do on CI.

We have to remove the `npm run docs` part as this depends on building part of the project, which may have been removed with trimja.  We should add an option to trimja-action to be able to include additional affected entries and then we can pass `prep-for-docs` too.