### PR TITLE
Use the latest trimja version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,8 @@ jobs:
     - run: npm run configure
     - name: Run trimja
       uses: elliotgoodrich/trimja-action@release
+      with:
+        version: '0.4.0'
     - run: ninja -k 0
 
   deploy:


### PR DESCRIPTION
This version removes build commands if only the order-only dependencies have changed.