### PR TITLE
Fix @ninjutsu-build/node require recursion

### DIFF
--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ninjutsu-build/node",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.18.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ninjutsu-build/node",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A ninjutsu-build plugin to generate ninja rules to execute JavaScript with node",
   "author": "Elliot Goodrich",
   "scripts": {

--- a/packages/node/src/depfile.cts
+++ b/packages/node/src/depfile.cts
@@ -20,7 +20,7 @@ export function open(out: string): void {
 
 /**
  * If the currently running script has been run inside `node` with the
- * appropriate bootstrap scripts injected by `@ninjutsu-build/tsc`, then
+ * appropriate bootstrap scripts injected by `@ninjutsu-build/node`, then
  * add the specified `path` to ninja's dynamic dependencies the this script.
  * Otherwise do nothing.
  *

--- a/packages/node/src/hookRequire.ts
+++ b/packages/node/src/hookRequire.ts
@@ -7,7 +7,16 @@ Module.prototype.require = function (this: NodeModule, id: string): string {
   const paths = require.resolve.paths(id);
   // If `paths` is null then this is a core module (e.g. http or fs)
   if (paths !== null) {
-    addDependency(require.resolve(id, { paths: [this.path] }));
+    try {
+      addDependency(require.resolve(id, { paths: [this.path] }));
+    } catch (e) {
+      // If the module cannot be found then swallow the exception and
+      // delegate to default behavior when calling `require` below.
+      // Note that our `require` function is also called for
+      // `hookRequire.js` as of Node v24 and `require.resolve` throws
+      // an exception when trying to resolve `./hookRequire.js` from
+      // itself.
+    }
   }
   return r.call(this, id);
 };


### PR DESCRIPTION
The injected require in `hookRequire.ts` is being called for itself. This is failing to resolve and throwing an exception, causing NodeJS to fail to run any JavaScript run with this hook.

We catch exceptions thrown here to silence the error (perhaps this is not the best fix), and this also will delegate throwing exceptions in the case we do not find a module to the default `require` instead of our `require.resolve` call.