### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/elliotgoodrich/ninjutsu-build/security/code-scanning/1](https://github.com/elliotgoodrich/ninjutsu-build/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yaml` so jobs default to least privilege (`contents: read`). Keep the existing `deploy` job-level permissions unchanged, since it needs elevated rights for GitHub Pages and OIDC token issuance.

Best single fix without changing functionality:
- In `.github/workflows/ci.yaml`, insert after the trigger section (`on: ...`) and before `jobs:`:
  - `permissions:`
  - `contents: read`

This ensures `build` is restricted appropriately while `deploy` still uses its explicit job-level permissions (`pages: write`, `id-token: write`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
