### PR TITLE
Rename `configure.mjs` to `ninjutsu.mjs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ commonly used JavaScript tools, `@ninjutsu-build` can be used to orchestrate
 your JavaScript and TypeScript builds.
 
 Ninjutsu Build is built using itself. You can see the
-[configure.mjs](configure/configure.mjs) script used to generate the
+[ninjutsu.mjs](configure/ninjutsu.mjs) script used to generate the
 `build.ninja` file.
 
 ## Why Ninjutsu Build?

--- a/configure/ninjutsu.mjs
+++ b/configure/ninjutsu.mjs
@@ -167,7 +167,7 @@ const transpile = makeSWCRule(ninja, {
   [orderOnlyDeps]: toolsInstalled,
 });
 
-checkFormatted({ in: "configure/configure.mjs" });
+checkFormatted({ in: "configure/ninjutsu.mjs" });
 const baseConfig = checkFormatted({ in: "tsconfig.json" });
 
 // Create a list of all targets that need to be ready before we

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "ninja",
-    "configure": "node configure/configure.mjs",
+    "configure": "node configure/ninjutsu.mjs",
     "docs": "cd configure && npx typedoc --sortEntryPoints false",
     "format": "npx @biomejs/biome format --write ."
   }


### PR DESCRIPTION
Try to start an idiom where the `@ninjutsu-build` configuration script is called `ninjutsu.*` so it's easier to search for examples in the future.