### PR TITLE
Move running `npm` out of `ninja`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         node-version: ${{ matrix.node }}
         cache: 'npm'
     - uses: seanmiddleditch/gha-setup-ninja@master
-    - run: cd configure && npm ci
-    - run: npm run configure
+    - run: node --run setup
+    - run: node --run configure
     - name: Run trimja
       uses: elliotgoodrich/trimja-action@release
     - run: ninja -k 0
@@ -49,8 +49,8 @@ jobs:
         node-version: latest
         cache: 'npm'
     - uses: seanmiddleditch/gha-setup-ninja@master
-    - run: cd configure && npm ci
-    - run: npm run configure
+    - run: node --run setup
+    - run: node --run configure
     - run: ninja -k 0 prep-for-docs
     - run: npm run docs
     - uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -123,12 +123,16 @@ After changing any of the mentioned TypeScript files mentioned in the script, ju
 
   1. Install [`node`](https://nodejs.org/en/download) (>=22)
   2. Install [`ninja`](https://ninja-build.org/) (>=1.11)
-  3. `npm ci --prefix configure`
+  4. `node --run setup`
   4. `node --run configure`
 
-### Building + linting + formatting + tests
+### Building + linting + checking formatting + tests
 
   1. `ninja`
+
+### Formatting
+
+  1. `node --run format`
 
 If new files are added then you must run `node --run configure` again
 to regenerate a file `build.ninja` that includes these new files.

--- a/configure/ninjutsu.mts
+++ b/configure/ninjutsu.mts
@@ -14,7 +14,7 @@ import {
 } from "@ninjutsu-build/tsc";
 import { makeNodeTestRule } from "@ninjutsu-build/node";
 import { makeCheckFormattedRule, makeLintRule } from "@ninjutsu-build/biome";
-import { basename, dirname, extname, join, relative } from "node:path/posix";
+import { basename, extname, join, relative } from "node:path/posix";
 import {
   resolve as resolveNative,
   relative as relativeNative,
@@ -22,30 +22,6 @@ import {
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { platform } from "os";
-
-// Create a rule to run `npm ci` in a particular directory
-function makeNpmCiRule(ninja: NinjaBuilder) {
-  const prefix = platform() === "win32" ? "cmd /c " : "";
-  const npmci = ninja.rule("npmci", {
-    command: prefix + "npm ci $args --silent",
-    description: "npm ci $args",
-    generator: 1,
-    out: needs<string>(),
-    in: needs<Input<string>>(),
-    args: "",
-  });
-  return (a: Omit<Parameters<typeof npmci>[0], "out">) => {
-    const { args = "", ...rest } = a;
-    const cwd = dirname(getInput(a.in));
-    const withCwd = cwd !== "." ? ` --prefix ${cwd}` : "";
-    return npmci({
-      ...a,
-      out: join(cwd, "node_modules", ".package-lock.json"),
-      args: withCwd + args,
-      ...rest,
-    });
-  };
-}
 
 function makeTarRule(ninja: NinjaBuilder) {
   // Intentionally avoid using `$in` as it must be the full path of the files
@@ -146,49 +122,21 @@ const workspacePkg = "package.json";
 const workspaceJSON = JSON.parse(readFileSync(workspacePkg, "utf-8"));
 
 ninja.output += "\n";
-ninja.comment("Rules + Installation");
-const npmci = makeNpmCiRule(ninja);
+ninja.comment("Rules");
 
 const { phony } = ninja;
-const packagesLinked = npmci({ in: workspacePkg, args: "--workspaces" });
-
 const biomeConfig = "biome.json";
-
-// We would like to check whether `package.json` is formatted correctly.
-// Most of the rules inject a build-order dependency on `npm ci` having
-// run correctly, but we also need a validation dependency from running
-// `npm ci` so we have a cycle (in JS only, ninja is happy with a cycle
-// containing a validations edge).  This means it's a bit convoluted to
-// create the `checkFormatted` rule but that what the code below does.
-let checkFormatted!: ReturnType<typeof makeCheckFormattedRule>;
-
-const toolsInstalled = npmci({
-  in: "configure/package.json",
-  [validations]: (toolsInstalled: string) => {
-    checkFormatted = makeCheckFormattedRule(ninja, {
-      configPath: biomeConfig,
-      [orderOnlyDeps]: toolsInstalled,
-    });
-    // Add a validation that `package.json` is formatted correctly.
-    // If we formatted after running `npmci` it would cause us to run it again
-    return checkFormatted({ in: "configure/package.json" })[validations];
-  },
+const checkFormatted = makeCheckFormattedRule(ninja, {
+  configPath: biomeConfig,
 });
 
-const tsc = makeTSCRule(ninja, { [orderOnlyDeps]: toolsInstalled });
-const typecheck = makeTypeCheckRule(ninja, {
-  [orderOnlyDeps]: toolsInstalled,
-});
+const tsc = makeTSCRule(ninja);
+const typecheck = makeTypeCheckRule(ninja);
 const test = makeNodeTestRule(ninja);
 const tar = makeTarRule(ninja);
 const copy = makeCopyRule(ninja);
-const lint = makeLintRule(ninja, {
-  configPath: biomeConfig,
-  [orderOnlyDeps]: toolsInstalled,
-});
-const transpile = makeSWCRule(ninja, {
-  [orderOnlyDeps]: toolsInstalled,
-});
+const lint = makeLintRule(ninja, { configPath: biomeConfig });
+const transpile = makeSWCRule(ninja);
 
 const baseConfig = checkFormatted({ in: "tsconfig.json" });
 const configTSConfig = checkFormatted({ in: "configure/tsconfig.json" });
@@ -200,7 +148,7 @@ const configureTypecheckedStamp = join(
 await typecheck({
   tsConfig: configTSConfig,
   out: configureTypecheckedStamp,
-  [orderOnlyDeps]: [toolsInstalled, baseConfig],
+  [orderOnlyDeps]: baseConfig,
 });
 checkFormatted({
   in: "configure/ninjutsu.mts",
@@ -229,15 +177,11 @@ for (const cwd of workspaceJSON.workspaces) {
 
   // Assume there is a target "@ninjutsu-build/foo/runnable" when the
   // `foo` package can be executed.
-  const dependenciesRunnable = [packagesLinked].concat(
-    localDependecies.map((d) => `${d}/runnable`),
-  );
+  const dependenciesRunnable = localDependecies.map((d) => `${d}/runnable`);
 
   // Assume there is a target "@ninjutsu-build/foo/typed" when the `foo`
   // package has all type declarations
-  const dependenciesTyped = [packagesLinked].concat(
-    localDependecies.map((d) => `${d}/typed`),
-  );
+  const dependenciesTyped = localDependecies.map((d) => `${d}/typed`);
 
   ninja.output += "\n";
   ninja.comment(cwd);

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "integration"
   ],
   "scripts": {
-    "build": "ninja",
+    "setup": "npm ci && npm ci --prefix configure",
     "configure": "node --experimental-strip-types configure/ninjutsu.mts",
+    "build": "ninja",
     "docs": "cd configure && npx typedoc --sortEntryPoints false",
     "format": "npx @biomejs/biome format --write ."
   }


### PR DESCRIPTION
Running `npm ci` in `ninja` does work, but it causes too many `orderOnlyDeps` to be used and to make the `ninjutsu.mts` file too complex. It also can cause issues when developing offline and we edit a `package.json` file and `ninja` tries (and fails) to call `npm ci`.