### PR TITLE
Improve node test runner

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
     "test": "ninja node -C ../.."
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=22"
   },
   "main": "dist/node.js",
   "exports": {

--- a/packages/node/src/testReporter.mts
+++ b/packages/node/src/testReporter.mts
@@ -5,40 +5,12 @@ import { tap, type TestEvent } from "node:test/reporters";
 export default async function* testReporter(
   source: AsyncGenerator<TestEvent>,
 ): AsyncGenerator<string, void> {
-  let buffer: string[] = [];
-  let hasFailure = false;
-  for await (const event of source) {
-    if (event.type === "test:pass") {
-      continue;
-    }
-    if (event.type === "test:fail") {
-      hasFailure = true;
-      for (const line of buffer) {
-        yield line;
-      }
-      buffer = [];
-    }
-    let firstLine = true;
-
-    // This is slightly hacky to inject our event like this as it means we need
-    // to call `tap` repeatedly and therefore need to constantly strip off the
-    // first line.  A better way will be to write an `AsyncGenerator` adapter that
-    // can spy on the events emitted to `tap` and tell us when we should dump
-    // everything that we've buffered.
-    const singleSource = async function* () {
-      yield event;
-    };
-    for await (const line of tap(singleSource())) {
-      // Skip the first line which is always `TAP version N`.
-      if (!firstLine) {
-        if (hasFailure) {
-          yield line;
-        } else {
-          buffer.push(line);
-        }
-      }
-
-      firstLine = false;
-    }
+  const events = await Array.fromAsync(source);
+  if (events.some((event) => event.type === "test:fail")) {
+    yield* tap(
+      (async function* () {
+        yield* events;
+      })(),
+    );
   }
 }

--- a/packages/node/src/testReporter.test.mts
+++ b/packages/node/src/testReporter.test.mts
@@ -1,0 +1,100 @@
+import test from "node:test";
+import { strict as assert } from "node:assert";
+import type { TestEvent } from "node:test/reporters";
+import testReporter from "./testReporter.mjs";
+
+async function* makeSource(events: TestEvent[]): AsyncGenerator<TestEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+async function collect(
+  reporter: AsyncGenerator<string, void>,
+): Promise<string[]> {
+  const lines: string[] = [];
+  for await (const line of reporter) {
+    lines.push(line);
+  }
+  return lines;
+}
+
+function makePassEvent(name: string, testNumber: number): TestEvent {
+  return {
+    type: "test:pass",
+    data: { name, nesting: 0, testNumber, details: { duration_ms: 1 } },
+  };
+}
+
+function makeFailEvent(name: string, testNumber: number): TestEvent {
+  return {
+    type: "test:fail",
+    data: {
+      name,
+      nesting: 0,
+      testNumber,
+      details: { duration_ms: 1, error: new Error("test failed") },
+    },
+  };
+}
+
+test("testReporter is completely silent when all tests pass", async () => {
+  const output = await collect(
+    testReporter(
+      makeSource([makePassEvent("test 1", 1), makePassEvent("test 2", 2)]),
+    ),
+  );
+  assert.deepEqual(output, []);
+});
+
+test("testReporter is silent for empty source", async () => {
+  const output = await collect(testReporter(makeSource([])));
+  assert.deepEqual(output, []);
+});
+
+test("testReporter outputs TAP when there is a failure", async () => {
+  const output = await collect(
+    testReporter(makeSource([makeFailEvent("failing test", 1)])),
+  );
+  const joined = output.join("");
+  assert.ok(output.length > 0, "should produce output on failure");
+  assert.ok(
+    joined.includes("not ok"),
+    "output should contain TAP failure line",
+  );
+  assert.ok(joined.includes("failing test"), "output should include test name");
+});
+
+test("testReporter includes buffered events before the failure", async () => {
+  const output = await collect(
+    testReporter(
+      makeSource([
+        makePassEvent("passing test", 1),
+        makeFailEvent("failing test", 2),
+      ]),
+    ),
+  );
+  const joined = output.join("");
+  assert.ok(
+    joined.includes("passing test"),
+    "should include buffered passing test",
+  );
+  assert.ok(joined.includes("failing test"), "should include failing test");
+});
+
+test("testReporter includes events after the failure", async () => {
+  const output = await collect(
+    testReporter(
+      makeSource([
+        makeFailEvent("failing test", 1),
+        makePassEvent("post-failure test", 2),
+      ]),
+    ),
+  );
+  const joined = output.join("");
+  assert.ok(joined.includes("failing test"), "should include failing test");
+  assert.ok(
+    joined.includes("post-failure test"),
+    "should include post-failure test",
+  );
+});

--- a/packages/node/tsconfig.tests.json
+++ b/packages/node/tsconfig.tests.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "files": ["src/node.test.mts"]
+  "files": ["src/node.test.mts", "src/testReporter.test.mts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "lib": ["ES2021"],
+    "lib": ["ESNext"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,


### PR DESCRIPTION
Avoid the hack where we assume the output of the TAP runner and repeatedly trim the first line.  Instead we buffer all events and only feed them into `tap` if there is a failure.

Use `Array.fromAsync`, available from NodeJS v22, now that our NodeJS requirement has increased.