### PR TITLE
Run CI weekly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * SAT'
 
 permissions:
   contents: read


### PR DESCRIPTION
Run the CI at midnight on Friday (00:00AM Saturday) each week so we get a chance to catch issues like incompatible NodeJS versions.

Doing this on a Friday gives me time on the weekend to fix it.