### PR TITLE
Import using public package name

### DIFF
--- a/packages/biome/src/biome.test.mts
+++ b/packages/biome/src/biome.test.mts
@@ -5,7 +5,7 @@ import {
   makeLintRule,
   makeFormatRule,
   makeFormatToRule,
-} from "./biome.js";
+} from "@ninjutsu-build/biome";
 import {
   NinjaBuilder,
   implicitDeps,

--- a/packages/core/src/core.test.mts
+++ b/packages/core/src/core.test.mts
@@ -14,7 +14,7 @@ import {
   implicitDeps,
   validations,
   implicitOut,
-} from "./core.js";
+} from "@ninjutsu-build/core";
 
 test("console", () => {
   assert.equal(console, "console");

--- a/packages/node/src/node.test.mts
+++ b/packages/node/src/node.test.mts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import { strict as assert } from "node:assert";
 import { NinjaBuilder, implicitDeps } from "@ninjutsu-build/core";
-import { makeNodeRule, makeNodeTestRule } from "./node.js";
+import { makeNodeRule, makeNodeTestRule } from "@ninjutsu-build/node";
 
 test("makeNodeRule", () => {
   const ninja = new NinjaBuilder();

--- a/packages/tsc/src/tsc.test.mts
+++ b/packages/tsc/src/tsc.test.mts
@@ -5,7 +5,7 @@ import {
   makeTypeCheckRule,
   compilerOptionsToString,
   compilerOptionsToArray,
-} from "./tsc.js";
+} from "@ninjutsu-build/tsc";
 import {
   NinjaBuilder,
   implicitDeps,


### PR DESCRIPTION
Ensure that we are exporting the correct files by importing using the package name instead of file paths in all of our unit tests.