### PR TITLE
Speed up node dependencies

### DIFF
--- a/experiments/node_dependency_benchmark/README.md
+++ b/experiments/node_dependency_benchmark/README.md
@@ -1,0 +1,15 @@
+Benchmarks three strategies for writing ninja depfiles from `packages/node/src/depfile.cts`:
+
+- **sync** — `writeFileSync` on every `addDependency` call (current behaviour)
+- **onExit** — buffer in memory, flush with `writeFileSync` in a `process.on('exit')` handler
+- **onBeforeExit** — buffer in memory, flush with async `write` in a `process.on('beforeExit')` handler
+
+```
+node run.mjs
+```
+
+`benchmark.mjs` can also be run directly for a single measurement:
+
+```
+node benchmark.mjs --type <sync|onExit|onBeforeExit> --count <n>
+```

--- a/experiments/node_dependency_benchmark/benchmark.mjs
+++ b/experiments/node_dependency_benchmark/benchmark.mjs
@@ -1,0 +1,85 @@
+import {
+  openSync,
+  writeFileSync,
+  readFileSync,
+  write,
+  closeSync,
+  unlinkSync,
+} from "node:fs";
+import { promisify } from "node:util";
+import { resolve, relative, isAbsolute, join } from "node:path";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+
+const asyncWrite = promisify(write);
+
+const typeIndex = process.argv.indexOf("--type");
+const type = process.argv[typeIndex + 1];
+if (!["sync", "onExit", "onBeforeExit"].includes(type ?? "")) {
+  console.error("Usage: node benchmark.mjs --type <sync|onExit|onBeforeExit> --count <n>");
+  process.exit(1);
+}
+
+const countIndex = process.argv.indexOf("--count");
+const N = Number(process.argv[countIndex + 1]);
+if (!Number.isInteger(N) || N <= 0) {
+  console.error("Usage: node benchmark.mjs --type <sync|onExit|onBeforeExit> --count <n>");
+  process.exit(1);
+}
+const out = join(tmpdir(), "ninjutsu_benchmark_out.txt");
+const depfilePath = out + ".depfile";
+const cwd = resolve();
+
+const paths = Array.from({ length: N }, (_, i) => {
+  if (i % 5 === 0) {
+    return resolve("node_modules", "some-package", `file_${i}.js`);
+  }
+  return resolve("packages", "node", "src", `file_${i}.ts`);
+});
+
+function computeDependency(path) {
+  const relPath = relative(cwd, path);
+  return (
+    relPath && !relPath.startsWith("..") && !isAbsolute(relPath)
+      ? relPath
+      : path
+  ).replaceAll("\\", "/");
+}
+
+const fd = openSync(depfilePath, "w");
+writeFileSync(fd, out + ":");
+
+let buffer = "";
+
+const loopStart = performance.now();
+
+if (type === "sync") {
+  for (const path of paths) {
+    writeFileSync(fd, " " + computeDependency(path));
+  }
+} else {
+  for (const path of paths) {
+    buffer += " " + computeDependency(path);
+  }
+}
+
+const loopMs = performance.now() - loopStart;
+
+let flushMs = 0;
+if (type === "onExit") {
+  const flushStart = performance.now();
+  writeFileSync(fd, buffer);
+  flushMs = performance.now() - flushStart;
+} else if (type === "onBeforeExit") {
+  const flushStart = performance.now();
+  await asyncWrite(fd, buffer);
+  flushMs = performance.now() - flushStart;
+}
+
+closeSync(fd);
+const contentHash = createHash("sha256")
+  .update(readFileSync(depfilePath))
+  .digest("hex");
+unlinkSync(depfilePath);
+
+console.log(JSON.stringify({ loopMs, flushMs, contentHash }));

--- a/experiments/node_dependency_benchmark/run.mjs
+++ b/experiments/node_dependency_benchmark/run.mjs
@@ -1,0 +1,129 @@
+import {
+  openSync,
+  writeFileSync,
+  readFileSync,
+  write,
+  closeSync,
+  unlinkSync,
+} from "node:fs";
+import { promisify } from "node:util";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve, relative, isAbsolute, join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+
+const asyncWrite = promisify(write);
+
+const RUNS = 10;
+const N = 10_000;
+const types = ["sync", "onExit", "onBeforeExit"];
+const N_ARG = String(N);
+const benchmarkPath = join(dirname(fileURLToPath(import.meta.url)), "benchmark.mjs");
+
+const cwd = resolve();
+const out = join(tmpdir(), "ninjutsu_benchmark_out.txt");
+const depfilePath = out + ".depfile";
+
+const paths = Array.from({ length: N }, (_, i) => {
+  if (i % 5 === 0) {
+    return resolve("node_modules", "some-package", `file_${i}.js`);
+  }
+  return resolve("packages", "node", "src", `file_${i}.ts`);
+});
+
+function computeDependency(path) {
+  const relPath = relative(cwd, path);
+  return (
+    relPath && !relPath.startsWith("..") && !isAbsolute(relPath)
+      ? relPath
+      : path
+  ).replaceAll("\\", "/");
+}
+
+async function captureOutput(type) {
+  const fd = openSync(depfilePath, "w");
+  writeFileSync(fd, out + ":");
+  let buffer = "";
+  if (type === "sync") {
+    for (const path of paths) writeFileSync(fd, " " + computeDependency(path));
+  } else {
+    for (const path of paths) buffer += " " + computeDependency(path);
+  }
+  if (type === "onExit") {
+    writeFileSync(fd, buffer);
+  } else if (type === "onBeforeExit") {
+    await asyncWrite(fd, buffer);
+  }
+  closeSync(fd);
+  const hash = createHash("sha256").update(readFileSync(depfilePath)).digest("hex");
+  unlinkSync(depfilePath);
+  return hash;
+}
+
+// Correctness check: run inline, no spawning
+console.log("Correctness check:");
+const syncHash = await captureOutput("sync");
+let allMatch = true;
+for (const type of types.filter((t) => t !== "sync")) {
+  const match = (await captureOutput(type)) === syncHash;
+  console.log(`  sync vs ${type.padEnd(14)}: ${match ? "✓ identical" : "✗ DIFFER"}`);
+  if (!match) allMatch = false;
+}
+if (!allMatch) process.exit(1);
+console.log();
+
+// Benchmark: each type gets RUNS fresh node processes
+function runOnce(type) {
+  const result = spawnSync(
+    process.execPath,
+    [benchmarkPath, "--type", type, "--count", N_ARG],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    console.error(`[${type}] process exited with ${result.status}:\n${result.stderr}`);
+    process.exit(1);
+  }
+  return JSON.parse(result.stdout.trim());
+}
+
+function stats(times) {
+  const sorted = [...times].sort((a, b) => a - b);
+  const sum = times.reduce((a, b) => a + b, 0);
+  return {
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    avg: sum / times.length,
+    median: sorted[Math.floor(sorted.length / 2)],
+  };
+}
+
+function fmt(ms) {
+  return `${ms.toFixed(2)}ms`;
+}
+
+function printStats(label, times) {
+  const { min, max, avg, median } = stats(times);
+  console.log(
+    `  ${label.padEnd(6)}: avg=${fmt(avg)}  med=${fmt(median)}  min=${fmt(min)}  max=${fmt(max)}`,
+  );
+}
+
+for (const type of types) {
+  const loopTimes = [];
+  const flushTimes = [];
+
+  for (let i = 0; i < RUNS; i++) {
+    const { loopMs, flushMs } = runOnce(type);
+    loopTimes.push(loopMs);
+    if (type !== "sync") flushTimes.push(flushMs);
+  }
+
+  console.log(`[${type}] ${N.toLocaleString()} calls over ${RUNS} runs:`);
+  printStats("loop", loopTimes);
+  if (flushTimes.length > 0) {
+    printStats("flush", flushTimes);
+    printStats("total", loopTimes.map((l, i) => l + flushTimes[i]));
+  }
+  console.log();
+}

--- a/packages/node/src/depfile.cts
+++ b/packages/node/src/depfile.cts
@@ -1,10 +1,12 @@
 import { openSync, writeFileSync } from "node:fs";
 import { resolve, relative, isAbsolute } from "node:path";
+import process from "node:process";
 
 declare global {
-  var fd: number;
   var cwd: string | undefined;
 }
+
+let buffer = "";
 
 /**
  * Open the corresponding depfile for the specified `out` file.  Note that this
@@ -14,8 +16,11 @@ declare global {
  */
 export function open(out: string): void {
   global.cwd = resolve();
-  global.fd = openSync(out + ".depfile", "w");
-  writeFileSync(global.fd, out + ":");
+  const fd = openSync(`${out}.depfile`, "w");
+  buffer = out + ":";
+  process.on("exit", () => {
+    writeFileSync(fd, buffer);
+  });
 }
 
 /**
@@ -71,7 +76,7 @@ export function open(out: string): void {
  * ```
  */
 export function addDependency(path: string): void {
-  const { cwd, fd } = global;
+  const { cwd } = global;
   if (cwd !== undefined) {
     const relPath = relative(cwd, path);
     const dependency = (
@@ -79,6 +84,6 @@ export function addDependency(path: string): void {
         ? relPath
         : path
     ).replaceAll("\\", "/");
-    writeFileSync(fd, " " + dependency);
+    buffer += " " + dependency;
   }
 }


### PR DESCRIPTION
Instead of sychronously writing to files on each call to `addDependency` we can instead buffer all of our dependency calls and write this at process exit in one go.